### PR TITLE
Add SeaChat logo dropdown navigation with main site and products access

### DIFF
--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -36,10 +36,12 @@
   },
   "hero": {
     "title": "Stop Juggling Apps <br> Unify Every Customer <br> Call, WhatsApp, and Chat <br> in One Simple Inbox.",
+    "titleWithGradient": "Stop Juggling Apps. <1>Unify Every Customer</1> Call, WhatsApp, and Chat in One Simple Inbox.",
     "description": "Seasalt.ai is the all-in-one contact center built for small businesses. Automate support, capture every lead, and manage all your conversations from a single screen.",
     "signUp": "Sign Up",
     "seeDemo": "Book A Demo",
-    "trustedBy": "Trusted by growing businesses worldwide"
+    "trustedBy": "Trusted by growing businesses worldwide",
+    "developerMessage": "Seasalt.ai brings developers an agentic communication tool for the following <1>tool use</1>:"
   },
   "seachat": {
     "common": {

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -29,9 +29,13 @@ const Hero = () => {
           {/* Left Column - Content */}
           <div className="lg:pr-8 w-full">
             <div className="text-center lg:text-left w-full">
-              <h1 className="text-3xl sm:text-4xl lg:text-6xl font-bold text-gray-900 leading-tight mb-6"
-                  dangerouslySetInnerHTML={{ __html: t('hero.title') }}
-              />
+              <h1 className="text-3xl sm:text-4xl lg:text-6xl font-bold text-gray-900 leading-tight mb-6">
+                Stop Juggling Apps.{' '}
+                <span className="bg-gradient-to-r from-blue-600 to-indigo-600 bg-clip-text text-transparent">
+                  Unify Every Customer
+                </span>{' '}
+                Call, WhatsApp, and Chat in One Simple Inbox.
+              </h1>
               
               <p className="text-xl text-gray-600 mb-8 max-w-2xl mx-auto lg:mx-0">
                 {t('hero.description')}
@@ -55,7 +59,11 @@ const Hero = () => {
               {/* Social Proof */}
               <div className="border-t border-gray-200 pt-6 sm:pt-8">
                 <p className="text-sm text-gray-500 mb-4">
-                  {t('hero.trustedBy')}
+                  Seasalt.ai brings developers an agentic communication tool for the following{' '}
+                  <code className="text-sm font-mono bg-red-50 text-red-800 px-3 py-1.5 rounded-md border border-red-200 font-semibold whitespace-nowrap">
+                    tool use
+                  </code>
+                  :
                 </p>
                 <div className="flex flex-wrap items-center justify-center lg:justify-start gap-3 sm:gap-4">
                   <code className="text-sm font-mono bg-red-50 text-red-800 px-3 py-1.5 rounded-md border border-red-200 font-semibold whitespace-nowrap">

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 import { Phone, MessageSquare, MessageCircle, Megaphone, BarChart3, Users } from 'lucide-react';
-import { useTranslation } from 'react-i18next';
+import { useTranslation, Trans } from 'react-i18next';
 
 
 const Hero = () => {
@@ -30,11 +30,12 @@ const Hero = () => {
           <div className="lg:pr-8 w-full">
             <div className="text-center lg:text-left w-full">
               <h1 className="text-3xl sm:text-4xl lg:text-6xl font-bold text-gray-900 leading-tight mb-6">
-                Stop Juggling Apps.{' '}
-                <span className="bg-gradient-to-r from-blue-600 to-indigo-600 bg-clip-text text-transparent">
-                  Unify Every Customer
-                </span>{' '}
-                Call, WhatsApp, and Chat in One Simple Inbox.
+                <Trans
+                  i18nKey="hero.titleWithGradient"
+                  components={{
+                    1: <span className="bg-gradient-to-r from-blue-600 to-indigo-600 bg-clip-text text-transparent" />
+                  }}
+                />
               </h1>
               
               <p className="text-xl text-gray-600 mb-8 max-w-2xl mx-auto lg:mx-0">
@@ -59,11 +60,12 @@ const Hero = () => {
               {/* Social Proof */}
               <div className="border-t border-gray-200 pt-6 sm:pt-8">
                 <p className="text-sm text-gray-500 mb-4">
-                  Seasalt.ai brings developers an agentic communication tool for the following{' '}
-                  <code className="text-sm font-mono bg-red-50 text-red-800 px-3 py-1.5 rounded-md border border-red-200 font-semibold whitespace-nowrap">
-                    tool use
-                  </code>
-                  :
+                  <Trans
+                    i18nKey="hero.developerMessage"
+                    components={{
+                      1: <code className="text-sm font-mono bg-red-50 text-red-800 px-3 py-1.5 rounded-md border border-red-200 font-semibold whitespace-nowrap" />
+                    }}
+                  />
                 </p>
                 <div className="flex flex-wrap items-center justify-center lg:justify-start gap-3 sm:gap-4">
                   <code className="text-sm font-mono bg-red-50 text-red-800 px-3 py-1.5 rounded-md border border-red-200 font-semibold whitespace-nowrap">

--- a/src/components/Industries.tsx
+++ b/src/components/Industries.tsx
@@ -63,15 +63,15 @@ const Industries = () => {
           </p>
           <div className="flex flex-col sm:flex-row gap-3 sm:gap-4 justify-center">
             <a
-               href="https://meetings.hubspot.com/seasalt-ai/seasalt-meeting/" className="bg-white text-blue-600 hover:bg-gray-50 px-6 sm:px-8 py-3 sm:py-4 rounded-lg text-base sm:text-lg font-semibold transition-all duration-200"
-            >
-              Book A Demo
-            </a>
-            <a
                href="https://seax.seasalt.ai/signup"
-               className="border-2 border-white text-white hover:bg-white hover:text-blue-600 px-6 sm:px-8 py-3 sm:py-4 rounded-lg text-base sm:text-lg font-semibold transition-all duration-200"
+               className="bg-white text-blue-600 hover:bg-gray-50 px-6 sm:px-8 py-3 sm:py-4 rounded-lg text-base sm:text-lg font-semibold transition-all duration-200"
              >
                Sign Up
+            </a>
+            <a
+               href="https://meetings.hubspot.com/seasalt-ai/seasalt-meeting/" className="border-2 border-white text-white hover:bg-white hover:text-blue-600 px-6 sm:px-8 py-3 sm:py-4 rounded-lg text-base sm:text-lg font-semibold transition-all duration-200"
+            >
+              Book A Demo
             </a>
           </div>
         </div>

--- a/src/seachat/components/Header.tsx
+++ b/src/seachat/components/Header.tsx
@@ -1,10 +1,11 @@
 import { useState } from 'react';
-import { Menu, X, ChevronDown, BookOpen } from 'lucide-react';
+import { Menu, X, ChevronDown, BookOpen, ChevronRight, Home } from 'lucide-react';
 import { Link, useLocation } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import LanguageSwitcher from '../../components/LanguageSwitcher';
 import { useLanguageAwareLinks } from '../../hooks/useLanguageAwareLinks';
 import { LANGUAGE_DETAILS } from '../../constants/languages';
+import { products } from '../../data/productsData';
 
 const Header = () => {
   const [isMenuOpen, setIsMenuOpen] = useState(false);
@@ -71,10 +72,88 @@ const Header = () => {
     <header className="fixed top-0 left-0 right-0 bg-white/95 backdrop-blur-sm border-b border-gray-100 z-50" dir={i18n.language === 'ar' ? 'rtl' : 'ltr'}>
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         <div className="flex justify-between items-center h-16">
-          {/* Logo */}
-          <Link to={createLink('seachat')} className="flex items-center">
-            <img src="/seachat-logo.png" alt="SeaChat Logo" className="h-10 w-auto" />
-          </Link>
+          {/* Logo with dropdown */}
+          <div className="relative">
+            <button 
+              onClick={() => handleDropdownToggle('logo')}
+              className="flex items-center hover:opacity-90 transition-opacity"
+            >
+              <img src="/seachat-logo.png" alt="SeaChat Logo" className="h-10 w-auto" />
+              <ChevronDown className="w-4 h-4 ml-2 text-gray-500" />
+            </button>
+            {openDropdown === 'logo' && (
+              <div className="absolute top-full left-0 mt-2 w-80 bg-white rounded-lg shadow-lg border border-gray-200 py-2 z-50">
+                {/* Main Site Link */}
+                <Link
+                  to={createLink('')}
+                  className="flex items-center px-4 py-3 text-sm text-gray-700 hover:bg-gray-50 border-b border-gray-100"
+                  onClick={() => setOpenDropdown(null)}
+                >
+                  <Home className="w-5 h-5 mr-3 text-blue-600" />
+                  <div>
+                    <div className="font-medium text-gray-900">Seasalt.ai Main Site</div>
+                    <div className="text-xs text-gray-500">All products and solutions</div>
+                  </div>
+                </Link>
+                
+                {/* Products */}
+                <div className="py-2">
+                  <div className="px-4 py-2 text-xs font-semibold text-gray-500 uppercase tracking-wider">Products</div>
+                  {products.map((product, index) => (
+                    <div key={index}>
+                      {product.subProducts ? (
+                        <div>
+                          <a
+                            href={product.href}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="block px-4 py-3 text-sm text-gray-700 hover:bg-gray-50"
+                          >
+                            <div className="font-medium">{product.title}</div>
+                            <div className="text-xs text-gray-500">{product.description}</div>
+                          </a>
+                          <div className="bg-gray-50 border-t border-gray-100">
+                            {product.subProducts.map((subProduct, subIndex) => (
+                              <a
+                                key={subIndex}
+                                href={subProduct.href}
+                                target="_blank"
+                                rel="noopener noreferrer"
+                                className="block px-8 py-2 text-sm text-gray-600 hover:text-gray-900 hover:bg-gray-100"
+                              >
+                                {subProduct.title}
+                              </a>
+                            ))}
+                          </div>
+                        </div>
+                      ) : (
+                        product.href.startsWith('/') ? (
+                          <Link
+                            to={createLink(product.href.substring(1))}
+                            className="block px-4 py-3 text-sm text-gray-700 hover:bg-gray-50"
+                            onClick={() => setOpenDropdown(null)}
+                          >
+                            <div className="font-medium">{product.title}</div>
+                            <div className="text-xs text-gray-500">{product.description}</div>
+                          </Link>
+                        ) : (
+                          <a
+                            href={product.href}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="block px-4 py-3 text-sm text-gray-700 hover:bg-gray-50"
+                          >
+                            <div className="font-medium">{product.title}</div>
+                            <div className="text-xs text-gray-500">{product.description}</div>
+                          </a>
+                        )
+                      )}
+                    </div>
+                  ))}
+                </div>
+              </div>
+            )}
+          </div>
 
           {/* Desktop Navigation */}
           <nav className="hidden lg:flex items-center space-x-8">
@@ -234,6 +313,18 @@ const Header = () => {
       {isMenuOpen && (
         <div className="lg:hidden bg-white border-b border-gray-100">
           <div className="px-4 py-6 space-y-6">
+            {/* Back to Main Site */}
+            <div className="pb-4 border-b border-gray-100">
+              <Link 
+                to={createLink('')} 
+                className="flex items-center text-gray-700 hover:text-blue-600 font-medium transition-colors"
+                onClick={() => setIsMenuOpen(false)}
+              >
+                <img src="/seasalt-ai-logo.png" alt="Seasalt.ai" className="h-6 w-auto mr-2" />
+                Back to Main Site
+              </Link>
+            </div>
+            
             {/* Features Section */}
             <div>
               <h3 className="font-semibold text-gray-900 mb-3">{t('seachat.header.features')}</h3>


### PR DESCRIPTION
- Remove Home dropdown from navigation menu
- Add clickable dropdown to SeaChat logo with chevron indicator
- Include 'Seasalt.ai Main Site' link with Home icon
- Add all products from main site (SeaChat, SeaX, SeaMeet, SeaVoice)
- Support sub-products for SeaVoice (TTS, STT, Discord Bot)
- Handle internal/external links appropriately
- Update Hero section with gradient text and developer messaging
- Swap Sign Up and Book A Demo buttons in Industries CTA
- Fix JSX syntax errors in header components
- Maintain mobile navigation with 'Back to Main Site' link