### PR TITLE
refactor: replace hardcoded HubSpot meeting URLs with global constant

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -6,6 +6,7 @@ import { useTranslation } from 'react-i18next';
 import { getProducts } from '../data/productsData';
 import { getSolutions } from '../data/solutionsData';
 import { getIndustries } from '../data/industriesData';
+import { MEETING_URL } from '../constants/urls';
 
 const Footer = () => {
   const { t, i18n } = useTranslation();
@@ -376,7 +377,7 @@ const Footer = () => {
               {t('footer.cta.startFreeTrial')}
             </a>
             <a
-              href="https://meetings.hubspot.com/seasalt-ai/seasalt-meeting/"
+              href={MEETING_URL}
               className="border-2 border-white text-white hover:bg-white hover:text-blue-600 px-6 sm:px-8 py-2.5 sm:py-3 rounded-lg font-semibold transition-all duration-200 text-sm sm:text-base"
             >
               {t('footer.cta.scheduleDemo')}

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -26,6 +26,7 @@ import { useLanguageAwareLinks } from '../hooks/useLanguageAwareLinks';
 import ProductLogoDropdown from './ProductLogoDropdown';
 import PhoneBanner from './PhoneBanner';
 import LanguageSwitcher from './LanguageSwitcher';
+import { MEETING_URL } from '../constants/urls';
 
 const Header = () => {
   const { t, i18n } = useTranslation();
@@ -252,7 +253,7 @@ const Header = () => {
                       return (
                         <a
                           key={index}
-                          href="https://meetings.hubspot.com/seasalt-ai/seasalt-meeting/"
+                          href={MEETING_URL}
                           className="flex items-center gap-3 px-4 py-2 text-sm text-gray-700 hover:bg-gray-50"
                           target="_blank"
                           rel="noopener noreferrer"
@@ -544,7 +545,7 @@ const Header = () => {
                         return (
                           <a
                             key={index}
-                            href="https://meetings.hubspot.com/seasalt-ai/seasalt-meeting/"
+                            href={MEETING_URL}
                             className="flex items-center py-2 text-sm text-gray-600 hover:text-gray-900 min-h-touch"
                             target="_blank"
                             rel="noopener noreferrer"

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -1,6 +1,7 @@
 import { MessageSquare, Phone, MessageCircle, Megaphone } from 'lucide-react';
 import { useTranslation, Trans } from 'react-i18next';
 import { useState, useEffect } from 'react';
+import { MEETING_URL } from '../constants/urls';
 
 const Hero = () => {
   const { t } = useTranslation();
@@ -52,7 +53,7 @@ const Hero = () => {
                   {t('hero.signUp')}
                 </a>
                 <a
-                   href="https://meetings.hubspot.com/seasalt-ai/seasalt-meeting/" className="border-2 border-gray-300 hover:border-blue-600 text-gray-700 hover:text-blue-600 px-8 py-4 rounded-lg text-lg font-semibold transition-all duration-200"
+                   href={MEETING_URL} className="border-2 border-gray-300 hover:border-blue-600 text-gray-700 hover:text-blue-600 px-8 py-4 rounded-lg text-lg font-semibold transition-all duration-200"
                 >
                   {t('hero.seeDemo')}
                 </a>

--- a/src/components/Industries.tsx
+++ b/src/components/Industries.tsx
@@ -1,6 +1,7 @@
 import { Link } from 'react-router-dom';
 import { getIndustries } from '../data/industriesData';
 import { useTranslation } from 'react-i18next';
+import { MEETING_URL } from '../constants/urls';
 
 const Industries = () => {
   const { i18n, t } = useTranslation();
@@ -69,7 +70,7 @@ const Industries = () => {
                {t('industries.cta.signUp')}
             </a>
             <a
-               href="https://meetings.hubspot.com/seasalt-ai/seasalt-meeting/" className="border-2 border-white text-white hover:bg-white hover:text-blue-600 px-6 sm:px-8 py-3 sm:py-4 rounded-lg text-base sm:text-lg font-semibold transition-all duration-200"
+               href={MEETING_URL} className="border-2 border-white text-white hover:bg-white hover:text-blue-600 px-6 sm:px-8 py-3 sm:py-4 rounded-lg text-base sm:text-lg font-semibold transition-all duration-200"
             >
               {t('industries.cta.bookDemo')}
             </a>

--- a/src/components/UseCases.tsx
+++ b/src/components/UseCases.tsx
@@ -1,5 +1,6 @@
 import { Headphones, Bot, MessageSquareText, Megaphone, MessageCircleMore, MessageSquare } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
+import { MEETING_URL } from '../constants/urls';
 
 const UseCases = () => {
   const { t } = useTranslation();
@@ -179,7 +180,7 @@ title: t('useCases.aiSupport.title'),
                {t('useCases.cta.signUp')}
             </a>
             <a
-              href="https://meetings.hubspot.com/seasalt-ai/seasalt-meeting/" className="border-2 border-white text-white hover:bg-white hover:text-blue-600 px-6 sm:px-8 py-3 sm:py-4 rounded-lg text-base sm:text-lg font-semibold transition-all duration-200"
+              href={MEETING_URL} className="border-2 border-white text-white hover:bg-white hover:text-blue-600 px-6 sm:px-8 py-3 sm:py-4 rounded-lg text-base sm:text-lg font-semibold transition-all duration-200"
             >
               {t('useCases.cta.bookDemo')}
             </a>

--- a/src/constants/urls.ts
+++ b/src/constants/urls.ts
@@ -1,0 +1,4 @@
+// External URLs used throughout the application
+export const MEETING_URL = 'https://meetings.hubspot.com/seasalt-ai/seasalt-meeting/';
+
+// Other external URLs can be added here as needed

--- a/src/pages/BlogPost.tsx
+++ b/src/pages/BlogPost.tsx
@@ -8,6 +8,7 @@ import { loadBlogPostByUrlPath, BlogPost } from '../utils/markdown';
 import SEOHelmet from '../components/SEOHelmet';
 import { LANGUAGE_DETAILS } from '../constants/languages';
 import BlogTableOfContents from '../components/BlogTableOfContents';
+import { MEETING_URL } from '../constants/urls';
 
 // Helper function to create a structured data for blog post
 const createArticleStructuredData = (post: BlogPost) => {
@@ -350,7 +351,7 @@ const BlogPostPage = () => {
                  Sign Up
               </a>
               <a
-                href="https://meetings.hubspot.com/seasalt-ai/seasalt-meeting/"
+                href={MEETING_URL}
                 className="border-2 border-white text-white hover:bg-white hover:text-blue-600 px-6 sm:px-8 py-3 sm:py-4 rounded-lg text-base sm:text-lg font-semibold transition-all duration-200"
               >
                 Schedule Demo

--- a/src/pages/ChannelsOverview.tsx
+++ b/src/pages/ChannelsOverview.tsx
@@ -6,6 +6,7 @@ import Footer from '../components/Footer';
 import SEOHelmet from '../components/SEOHelmet';
 import { useTranslation } from 'react-i18next';
 import { SUPPORTED_LANGUAGES } from '../constants/languages';
+import { MEETING_URL } from '../constants/urls';
 
 const ChannelsOverview = () => {
   const { i18n } = useTranslation();
@@ -340,7 +341,7 @@ const ChannelsOverview = () => {
                  Sign Up
               </a>
               <a
-                href="https://meetings.hubspot.com/seasalt-ai/seasalt-meeting/" className="border-2 border-white text-white hover:bg-white hover:text-blue-600 px-8 py-4 rounded-lg text-lg font-semibold transition-all duration-200"
+                href={MEETING_URL} className="border-2 border-white text-white hover:bg-white hover:text-blue-600 px-8 py-4 rounded-lg text-lg font-semibold transition-all duration-200"
               >
                 Book A Demo
               </a>

--- a/src/pages/CompareUsOverview.tsx
+++ b/src/pages/CompareUsOverview.tsx
@@ -6,6 +6,7 @@ import Footer from '../components/Footer';
 import SEOHelmet from '../components/SEOHelmet';
 import { useTranslation } from 'react-i18next';
 import { SUPPORTED_LANGUAGES } from '../constants/languages';
+import { MEETING_URL } from '../constants/urls';
 
 const CompareUsOverview = () => {
   const { i18n } = useTranslation();
@@ -279,7 +280,7 @@ const CompareUsOverview = () => {
                  Sign Up
               </a>
               <a
-                href="https://meetings.hubspot.com/seasalt-ai/seasalt-meeting/" className="border-2 border-white text-white hover:bg-white hover:text-blue-600 px-8 py-4 rounded-lg text-lg font-semibold transition-all duration-200"
+                href={MEETING_URL} className="border-2 border-white text-white hover:bg-white hover:text-blue-600 px-8 py-4 rounded-lg text-lg font-semibold transition-all duration-200"
               >
                 Book A Demo
               </a>

--- a/src/pages/Pricing.tsx
+++ b/src/pages/Pricing.tsx
@@ -6,6 +6,7 @@ import SEOHelmet from '../components/SEOHelmet';
 import Header from '../components/Header';
 import Footer from '../components/Footer';
 import { SUPPORTED_LANGUAGES } from '../constants/languages';
+import { MEETING_URL } from '../constants/urls';
 
 const PricingPage = () => {
   const { i18n } = useTranslation();
@@ -582,7 +583,7 @@ const PricingPage = () => {
                   </div>
                 </div>
                 <a 
-                  href="https://meetings.hubspot.com/seasalt-ai/seasalt-meeting/"
+                  href={MEETING_URL}
                   className="block bg-green-600 hover:bg-green-700 text-white px-4 py-2 rounded-lg font-semibold transition-colors text-center text-sm"
                 >
                   Contact Us
@@ -884,7 +885,7 @@ const PricingPage = () => {
                 </a>
                 
                 <a
-                  href="https://meetings.hubspot.com/seasalt-ai/seasalt-meeting/"
+                  href={MEETING_URL}
                   className="inline-flex items-center px-6 py-3 text-lg font-semibold text-white border-2 border-white rounded-xl hover:bg-white hover:text-blue-900 transition-all duration-300 transform hover:scale-105"
                 >
                   📞 Talk to Sales

--- a/src/pages/SeaHealth.tsx
+++ b/src/pages/SeaHealth.tsx
@@ -2,6 +2,7 @@ import Header from '../components/Header';
 import Footer from '../components/Footer';
 import { FaUserPlus, FaRobot, FaChartBar, FaPhoneAlt, FaCommentDots, FaCalendarCheck, FaHeadset, FaExclamationTriangle, FaUserMd, FaPhoneSlash, FaRegSmile, FaRegClock, FaRegHandshake, FaRegComments, FaRegLifeRing, FaRegBell, FaRegListAlt, FaRegStar, FaRegCalendarPlus, FaRegCalendarCheck, FaRegArrowAltCircleUp, FaRegArrowAltCircleDown } from 'react-icons/fa';
 import SEOHelmet from '../components/SEOHelmet';
+import { MEETING_URL } from '../constants/urls';
 
 const SeaHealth = () => (
   <div className="min-h-screen bg-white flex flex-col">
@@ -33,7 +34,7 @@ const SeaHealth = () => (
               <span className="text-2xl md:text-2xl text-center leading-snug break-words">Front Office Call Analytics</span>
             </li>
           </ul>
-          <a href="https://meetings.hubspot.com/seasalt-ai/seasalt-meeting/" target="_blank" rel="noopener noreferrer" className="inline-block bg-gradient-to-r from-blue-500 to-cyan-400 hover:from-blue-600 hover:to-green-400 text-white px-10 py-5 rounded-2xl text-2xl font-extrabold shadow-2xl transition-all duration-200 mb-4 animate-fade-in">Book a Demo Today!</a>
+          <a href={MEETING_URL} target="_blank" rel="noopener noreferrer" className="inline-block bg-gradient-to-r from-blue-500 to-cyan-400 hover:from-blue-600 hover:to-green-400 text-white px-10 py-5 rounded-2xl text-2xl font-extrabold shadow-2xl transition-all duration-200 mb-4 animate-fade-in">Book a Demo Today!</a>
           <p className="text-lg md:text-xl text-blue-800 drop-shadow-lg animate-fade-in-up delay-300">AI-powered front office for healthcare. Never miss a call, complaint, or appointment again.</p>
         </div>
         <style>{`
@@ -317,7 +318,7 @@ const SeaHealth = () => (
       {/* Final CTA */}
       <section className="py-16 bg-white text-center">
         <h2 className="text-5xl md:text-6xl font-extrabold text-transparent bg-clip-text bg-gradient-to-r from-blue-500 via-cyan-400 to-green-400 mb-6 animate-gradient-x">Ready to transform patient interactions?</h2>
-        <a href="https://meetings.hubspot.com/seasalt-ai/seasalt-meeting/" target="_blank" rel="noopener noreferrer" className="inline-block bg-gradient-to-r from-blue-500 to-cyan-400 hover:from-blue-600 hover:to-green-400 text-white px-10 py-5 rounded-2xl text-2xl font-extrabold shadow-2xl transition-all duration-200 mb-4 animate-fade-in">Book a Demo Today!</a>
+        <a href={MEETING_URL} target="_blank" rel="noopener noreferrer" className="inline-block bg-gradient-to-r from-blue-500 to-cyan-400 hover:from-blue-600 hover:to-green-400 text-white px-10 py-5 rounded-2xl text-2xl font-extrabold shadow-2xl transition-all duration-200 mb-4 animate-fade-in">Book a Demo Today!</a>
       </section>
     </main>
     <Footer />

--- a/src/pages/channels/ContactForms.tsx
+++ b/src/pages/channels/ContactForms.tsx
@@ -4,6 +4,7 @@ import { Link } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import Header from '../../components/Header';
 import Footer from '../../components/Footer';
+import { MEETING_URL } from '../../constants/urls';
 
 const ContactForms = () => {
   const { i18n } = useTranslation();
@@ -129,7 +130,7 @@ const ContactForms = () => {
                     Connect Your Forms
                   </a>
                   <a
-                    href="https://meetings.hubspot.com/seasalt-ai/seasalt-meeting/"
+                    href={MEETING_URL}
                     className="border-2 border-gray-800 text-gray-800 hover:bg-gray-800 hover:text-white px-8 py-4 rounded-lg text-lg font-semibold transition-all duration-200"
                   >
                     See Demo

--- a/src/pages/channels/FacebookMessenger.tsx
+++ b/src/pages/channels/FacebookMessenger.tsx
@@ -4,6 +4,7 @@ import { Link } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import Header from '../../components/Header';
 import Footer from '../../components/Footer';
+import { MEETING_URL } from '../../constants/urls';
 
 const FacebookMessenger = () => {
   const { i18n } = useTranslation();
@@ -86,7 +87,7 @@ const FacebookMessenger = () => {
                     Connect Messenger Now
                   </a>
                   <a
-                    href="https://meetings.hubspot.com/seasalt-ai/seasalt-meeting/"
+                    href={MEETING_URL}
                     className="border-2 border-blue-600 text-blue-600 hover:bg-blue-600 hover:text-white px-8 py-4 rounded-lg text-lg font-semibold transition-all duration-200"
                   >
                     See Demo
@@ -273,7 +274,7 @@ const FacebookMessenger = () => {
                 Connect Messenger
               </a>
               <a
-                href="https://meetings.hubspot.com/seasalt-ai/seasalt-meeting/" className="border-2 border-white text-white hover:bg-white hover:text-blue-600 px-8 py-4 rounded-lg text-lg font-semibold transition-all duration-200"
+                href={MEETING_URL} className="border-2 border-white text-white hover:bg-white hover:text-blue-600 px-8 py-4 rounded-lg text-lg font-semibold transition-all duration-200"
               >
                 Book A Demo
               </a>

--- a/src/pages/channels/Instagram.tsx
+++ b/src/pages/channels/Instagram.tsx
@@ -4,6 +4,7 @@ import { Link } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import Header from '../../components/Header';
 import Footer from '../../components/Footer';
+import { MEETING_URL } from '../../constants/urls';
 
 const InstagramPage = () => {
   const { i18n } = useTranslation();
@@ -90,7 +91,7 @@ const InstagramPage = () => {
                     Automate Instagram DMs
                   </a>
                   <a
-                    href="https://meetings.hubspot.com/seasalt-ai/seasalt-meeting/"
+                    href={MEETING_URL}
                     className="border-2 border-pink-600 text-pink-600 hover:bg-pink-600 hover:text-white px-8 py-4 rounded-lg text-lg font-semibold transition-all duration-200"
                   >
                     See Demo
@@ -246,7 +247,7 @@ const InstagramPage = () => {
                 Start Automation
               </a>
               <a
-                href="https://meetings.hubspot.com/seasalt-ai/seasalt-meeting/"
+                href={MEETING_URL}
                 className="border-2 border-white text-white hover:bg-white hover:text-pink-600 px-8 py-4 rounded-lg text-lg font-semibold transition-all duration-200"
               >
                 See Demo

--- a/src/pages/channels/Line.tsx
+++ b/src/pages/channels/Line.tsx
@@ -4,6 +4,7 @@ import { Link } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import Header from '../../components/Header';
 import Footer from '../../components/Footer';
+import { MEETING_URL } from '../../constants/urls';
 
 const Line = () => {
   const { i18n } = useTranslation();
@@ -113,7 +114,7 @@ const Line = () => {
                     Start LINE Integration
                   </a>
                   <a
-                    href="https://meetings.hubspot.com/seasalt-ai/seasalt-meeting/"
+                    href={MEETING_URL}
                     className="border-2 border-green-500 text-green-500 hover:bg-green-500 hover:text-white px-8 py-4 rounded-lg text-lg font-semibold transition-all duration-200"
                   >
                     See Demo

--- a/src/pages/channels/PhoneCalls.tsx
+++ b/src/pages/channels/PhoneCalls.tsx
@@ -4,6 +4,7 @@ import { Link } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import Header from '../../components/Header';
 import Footer from '../../components/Footer';
+import { MEETING_URL } from '../../constants/urls';
 
 const PhoneCalls = () => {
   const { i18n } = useTranslation();
@@ -93,7 +94,7 @@ const PhoneCalls = () => {
                     Start Making Calls Today
                   </a>
                   <a
-                    href="https://meetings.hubspot.com/seasalt-ai/seasalt-meeting/"
+                    href={MEETING_URL}
                     className="border-2 border-blue-600 text-blue-600 hover:bg-blue-600 hover:text-white px-8 py-4 rounded-lg text-lg font-semibold transition-all duration-200"
                   >
                     See Demo

--- a/src/pages/channels/SMS.tsx
+++ b/src/pages/channels/SMS.tsx
@@ -4,6 +4,7 @@ import { Link } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import Header from '../../components/Header';
 import Footer from '../../components/Footer';
+import { MEETING_URL } from '../../constants/urls';
 
 const SMS = () => {
   const { i18n } = useTranslation();
@@ -90,7 +91,7 @@ const SMS = () => {
                     Start SMS Campaigns
                   </a>
                   <a
-                    href="https://meetings.hubspot.com/seasalt-ai/seasalt-meeting/"
+                    href={MEETING_URL}
                     className="border-2 border-purple-600 text-purple-600 hover:bg-purple-600 hover:text-white px-8 py-4 rounded-lg text-lg font-semibold transition-all duration-200"
                   >
                     See Demo

--- a/src/pages/channels/WebsiteChat.tsx
+++ b/src/pages/channels/WebsiteChat.tsx
@@ -3,6 +3,7 @@ import { Monitor, Zap, Users, BarChart3, ArrowLeft, Code, Palette } from 'lucide
 import { Link } from 'react-router-dom';
 import Header from '../../components/Header';
 import Footer from '../../components/Footer';
+import { MEETING_URL } from '../../constants/urls';
 
 const WebsiteChat = () => {
   // Scroll to top when component mounts
@@ -92,7 +93,7 @@ const WebsiteChat = () => {
                     Get Your Free Widget
                   </a>
                   <a
-                    href="https://meetings.hubspot.com/seasalt-ai/seasalt-meeting/" className="border-2 border-indigo-600 text-indigo-600 hover:bg-indigo-600 hover:text-white px-8 py-4 rounded-lg text-lg font-semibold transition-all duration-200"
+                    href={MEETING_URL} className="border-2 border-indigo-600 text-indigo-600 hover:bg-indigo-600 hover:text-white px-8 py-4 rounded-lg text-lg font-semibold transition-all duration-200"
                   >
                     Book A Demo
                   </a>

--- a/src/pages/channels/WebsiteWidget.tsx
+++ b/src/pages/channels/WebsiteWidget.tsx
@@ -4,6 +4,7 @@ import { Link } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import Header from '../../components/Header';
 import Footer from '../../components/Footer';
+import { MEETING_URL } from '../../constants/urls';
 
 const WebsiteWidget = () => {
   const { i18n } = useTranslation();
@@ -124,7 +125,7 @@ const WebsiteWidget = () => {
                     Deploy Widget Now
                   </a>
                   <a
-                    href="https://meetings.hubspot.com/seasalt-ai/seasalt-meeting/" className="border-2 border-orange-600 text-orange-600 hover:bg-orange-600 hover:text-white px-8 py-4 rounded-lg text-lg font-semibold transition-all duration-200"
+                    href={MEETING_URL} className="border-2 border-orange-600 text-orange-600 hover:bg-orange-600 hover:text-white px-8 py-4 rounded-lg text-lg font-semibold transition-all duration-200"
                   >
                     Book A Demo
                   </a>

--- a/src/pages/channels/WhatsApp.tsx
+++ b/src/pages/channels/WhatsApp.tsx
@@ -6,6 +6,7 @@ import Footer from '../../components/Footer';
 import SEOHelmet from '../../components/SEOHelmet';
 import { useTranslation } from 'react-i18next';
 import { SUPPORTED_LANGUAGES } from '../../constants/languages';
+import { MEETING_URL } from '../../constants/urls';
 
 const WhatsApp = () => {
   const { i18n } = useTranslation();
@@ -92,7 +93,7 @@ const WhatsApp = () => {
                     Connect WhatsApp in 10 Minutes
                   </a>
                   <a
-                    href="https://meetings.hubspot.com/seasalt-ai/seasalt-meeting/"
+                    href={MEETING_URL}
                     className="border-2 border-green-600 text-green-600 hover:bg-green-600 hover:text-white px-8 py-4 rounded-lg text-lg font-semibold transition-all duration-200"
                   >
                     See Demo

--- a/src/pages/compare/AircallAlternative.tsx
+++ b/src/pages/compare/AircallAlternative.tsx
@@ -3,6 +3,7 @@ import { Link } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import Header from '../../components/Header';
 import Footer from '../../components/Footer';
+import { MEETING_URL } from '../../constants/urls';
 
 const AircallAlternative = () => {
   const { i18n } = useTranslation();
@@ -229,7 +230,7 @@ const AircallAlternative = () => {
                  Sign Up
               </a>
               <a
-                href="https://meetings.hubspot.com/seasalt-ai/seasalt-meeting/" className="border-2 border-white text-white hover:bg-white hover:text-blue-600 px-8 py-4 rounded-lg text-lg font-semibold transition-all duration-200"
+                href={MEETING_URL} className="border-2 border-white text-white hover:bg-white hover:text-blue-600 px-8 py-4 rounded-lg text-lg font-semibold transition-all duration-200"
               >
                 Book A Demo
               </a>

--- a/src/pages/compare/AvayaAlternative.tsx
+++ b/src/pages/compare/AvayaAlternative.tsx
@@ -3,6 +3,7 @@ import { Link } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import Header from '../../components/Header';
 import Footer from '../../components/Footer';
+import { MEETING_URL } from '../../constants/urls';
 
 const AvayaAlternative = () => {
   const { i18n } = useTranslation();
@@ -266,7 +267,7 @@ const AvayaAlternative = () => {
                  Sign Up
               </a>
               <a
-                href="https://meetings.hubspot.com/seasalt-ai/seasalt-meeting/" className="border-2 border-white text-white hover:bg-white hover:text-indigo-600 px-8 py-4 rounded-lg text-lg font-semibold transition-all duration-200"
+                href={MEETING_URL} className="border-2 border-white text-white hover:bg-white hover:text-indigo-600 px-8 py-4 rounded-lg text-lg font-semibold transition-all duration-200"
               >
                 Book A Demo
               </a>

--- a/src/pages/compare/DialpadAlternative.tsx
+++ b/src/pages/compare/DialpadAlternative.tsx
@@ -3,6 +3,7 @@ import { Link } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import Header from '../../components/Header';
 import Footer from '../../components/Footer';
+import { MEETING_URL } from '../../constants/urls';
 
 const DialpadAlternative = () => {
   const { i18n } = useTranslation();
@@ -387,7 +388,7 @@ const DialpadAlternative = () => {
                  Sign Up
               </a>
               <a
-                href="https://meetings.hubspot.com/seasalt-ai/seasalt-meeting/" className="border-2 border-white text-white hover:bg-white hover:text-blue-600 px-8 py-4 rounded-lg text-lg font-semibold transition-all duration-200"
+                href={MEETING_URL} className="border-2 border-white text-white hover:bg-white hover:text-blue-600 px-8 py-4 rounded-lg text-lg font-semibold transition-all duration-200"
               >
                 Book A Demo
               </a>

--- a/src/pages/compare/EightXEightAlternative.tsx
+++ b/src/pages/compare/EightXEightAlternative.tsx
@@ -3,6 +3,7 @@ import { Link } from 'react-router-dom';
 import Header from '../../components/Header';
 import Footer from '../../components/Footer';
 import { useNormalizedLanguage } from '../../hooks/useNormalizedLanguage';
+import { MEETING_URL } from '../../constants/urls';
 
 const EightXEightAlternative = () => {
   const currentLanguage = useNormalizedLanguage();
@@ -354,7 +355,7 @@ const EightXEightAlternative = () => {
                  Sign Up
               </a>
               <a
-                href="https://meetings.hubspot.com/seasalt-ai/seasalt-meeting/" className="border-2 border-white text-white hover:bg-white hover:text-gray-800 px-8 py-4 rounded-lg text-lg font-semibold transition-all duration-200"
+                href={MEETING_URL} className="border-2 border-white text-white hover:bg-white hover:text-gray-800 px-8 py-4 rounded-lg text-lg font-semibold transition-all duration-200"
               >
                 Book A Demo
               </a>

--- a/src/pages/compare/Five9Alternative.tsx
+++ b/src/pages/compare/Five9Alternative.tsx
@@ -3,6 +3,7 @@ import { Link } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import Header from '../../components/Header';
 import Footer from '../../components/Footer';
+import { MEETING_URL } from '../../constants/urls';
 
 const Five9Alternative = () => {
   const { i18n } = useTranslation();
@@ -268,7 +269,7 @@ const Five9Alternative = () => {
                  Sign Up
               </a>
               <a
-                href="https://meetings.hubspot.com/seasalt-ai/seasalt-meeting/" className="border-2 border-white text-white hover:bg-white hover:text-orange-600 px-8 py-4 rounded-lg text-lg font-semibold transition-all duration-200"
+                href={MEETING_URL} className="border-2 border-white text-white hover:bg-white hover:text-orange-600 px-8 py-4 rounded-lg text-lg font-semibold transition-all duration-200"
               >
                 Book A Demo
               </a>

--- a/src/pages/compare/GenesysAlternative.tsx
+++ b/src/pages/compare/GenesysAlternative.tsx
@@ -3,6 +3,7 @@ import { Link } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import Header from '../../components/Header';
 import Footer from '../../components/Footer';
+import { MEETING_URL } from '../../constants/urls';
 
 const GenesysAlternative = () => {
   const { i18n } = useTranslation();
@@ -199,7 +200,7 @@ const GenesysAlternative = () => {
                  Sign Up
               </a>
               <a
-                href="https://meetings.hubspot.com/seasalt-ai/seasalt-meeting/" className="border-2 border-white text-white hover:bg-white hover:text-purple-600 px-8 py-4 rounded-lg text-lg font-semibold transition-all duration-200"
+                href={MEETING_URL} className="border-2 border-white text-white hover:bg-white hover:text-purple-600 px-8 py-4 rounded-lg text-lg font-semibold transition-all duration-200"
               >
                 Book A Demo
               </a>

--- a/src/pages/compare/GoogleVoiceAlternative.tsx
+++ b/src/pages/compare/GoogleVoiceAlternative.tsx
@@ -3,6 +3,7 @@ import { Link } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import Header from '../../components/Header';
 import Footer from '../../components/Footer';
+import { MEETING_URL } from '../../constants/urls';
 
 const GoogleVoiceAlternative = () => {
   const { i18n } = useTranslation();
@@ -288,7 +289,7 @@ const GoogleVoiceAlternative = () => {
                  Sign Up
               </a>
               <a
-                href="https://meetings.hubspot.com/seasalt-ai/seasalt-meeting/"
+                href={MEETING_URL}
                 className="border-2 border-white text-white hover:bg-white hover:text-green-600 px-8 py-4 rounded-lg text-lg font-semibold transition-all duration-200"
               >
                 Book a Demo

--- a/src/pages/compare/IntercomAlternative.tsx
+++ b/src/pages/compare/IntercomAlternative.tsx
@@ -3,6 +3,7 @@ import { Link } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import Header from '../../components/Header';
 import Footer from '../../components/Footer';
+import { MEETING_URL } from '../../constants/urls';
 
 const IntercomAlternative = () => {
   const { i18n } = useTranslation();
@@ -345,7 +346,7 @@ const IntercomAlternative = () => {
                  Sign Up
               </a>
               <a
-                href="https://meetings.hubspot.com/seasalt-ai/seasalt-meeting/" className="border-2 border-white text-white hover:bg-white hover:text-purple-600 px-8 py-4 rounded-lg text-lg font-semibold transition-all duration-200"
+                href={MEETING_URL} className="border-2 border-white text-white hover:bg-white hover:text-purple-600 px-8 py-4 rounded-lg text-lg font-semibold transition-all duration-200"
               >
                 Book A Demo
               </a>

--- a/src/pages/compare/KustomerAlternative.tsx
+++ b/src/pages/compare/KustomerAlternative.tsx
@@ -3,6 +3,7 @@ import { Link } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import Header from '../../components/Header';
 import Footer from '../../components/Footer';
+import { MEETING_URL } from '../../constants/urls';
 
 const KustomerAlternative = () => {
   const { i18n } = useTranslation();
@@ -349,7 +350,7 @@ const KustomerAlternative = () => {
                  Sign Up
               </a>
               <a
-                href="https://meetings.hubspot.com/seasalt-ai/seasalt-meeting/" className="border-2 border-white text-white hover:bg-white hover:text-green-600 px-8 py-4 rounded-lg text-lg font-semibold transition-all duration-200"
+                href={MEETING_URL} className="border-2 border-white text-white hover:bg-white hover:text-green-600 px-8 py-4 rounded-lg text-lg font-semibold transition-all duration-200"
               >
                 Book A Demo
               </a>

--- a/src/pages/compare/OpenPhoneAlternative.tsx
+++ b/src/pages/compare/OpenPhoneAlternative.tsx
@@ -3,6 +3,7 @@ import { Link } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import Header from '../../components/Header';
 import Footer from '../../components/Footer';
+import { MEETING_URL } from '../../constants/urls';
 
 const OpenPhoneAlternative = () => {
   const { i18n } = useTranslation();
@@ -411,7 +412,7 @@ const OpenPhoneAlternative = () => {
                  Sign Up
               </a>
               <a
-                href="https://meetings.hubspot.com/seasalt-ai/seasalt-meeting/"
+                href={MEETING_URL}
                 className="border-2 border-white text-white hover:bg-white hover:text-green-600 px-8 py-4 rounded-lg text-lg font-semibold transition-all duration-200"
               >
                 Book a Demo

--- a/src/pages/compare/RespondIoAlternative.tsx
+++ b/src/pages/compare/RespondIoAlternative.tsx
@@ -3,6 +3,7 @@ import { Link } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import Header from '../../components/Header';
 import Footer from '../../components/Footer';
+import { MEETING_URL } from '../../constants/urls';
 
 const RespondIoAlternative = () => {
   const { i18n } = useTranslation();
@@ -274,7 +275,7 @@ const RespondIoAlternative = () => {
                  Sign Up
               </a>
               <a
-                href="https://meetings.hubspot.com/seasalt-ai/seasalt-meeting/" className="border-2 border-white text-white hover:bg-white hover:text-blue-600 px-8 py-4 rounded-lg text-lg font-semibold transition-all duration-200"
+                href={MEETING_URL} className="border-2 border-white text-white hover:bg-white hover:text-blue-600 px-8 py-4 rounded-lg text-lg font-semibold transition-all duration-200"
               >
                 Book A Demo
               </a>

--- a/src/pages/compare/RingCentralAlternative.tsx
+++ b/src/pages/compare/RingCentralAlternative.tsx
@@ -3,6 +3,7 @@ import { Link } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import Header from '../../components/Header';
 import Footer from '../../components/Footer';
+import { MEETING_URL } from '../../constants/urls';
 
 const RingCentralAlternative = () => {
   const { i18n } = useTranslation();
@@ -207,7 +208,7 @@ const RingCentralAlternative = () => {
                  Sign Up
               </a>
               <a
-                href="https://meetings.hubspot.com/seasalt-ai/seasalt-meeting/" className="border-2 border-white text-white hover:bg-white hover:text-blue-600 px-8 py-4 rounded-lg text-lg font-semibold transition-all duration-200"
+                href={MEETING_URL} className="border-2 border-white text-white hover:bg-white hover:text-blue-600 px-8 py-4 rounded-lg text-lg font-semibold transition-all duration-200"
               >
                 Book A Demo
               </a>

--- a/src/pages/compare/ThreeCXAlternative.tsx
+++ b/src/pages/compare/ThreeCXAlternative.tsx
@@ -3,6 +3,7 @@ import { Link } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import Header from '../../components/Header';
 import Footer from '../../components/Footer';
+import { MEETING_URL } from '../../constants/urls';
 
 const ThreeCXAlternative = () => {
   const { i18n } = useTranslation();
@@ -310,7 +311,7 @@ const ThreeCXAlternative = () => {
                  Sign Up
               </a>
               <a
-                href="https://meetings.hubspot.com/seasalt-ai/seasalt-meeting/" className="border-2 border-white text-white hover:bg-white hover:text-indigo-600 px-8 py-4 rounded-lg text-lg font-semibold transition-all duration-200"
+                href={MEETING_URL} className="border-2 border-white text-white hover:bg-white hover:text-indigo-600 px-8 py-4 rounded-lg text-lg font-semibold transition-all duration-200"
               >
                 Book A Demo
               </a>

--- a/src/pages/industries/IndustryPageTemplate.tsx
+++ b/src/pages/industries/IndustryPageTemplate.tsx
@@ -6,6 +6,7 @@ import Footer from '../../components/Footer';
 import SEOHelmet from '../../components/SEOHelmet';
 import { useTranslation } from 'react-i18next';
 import { SUPPORTED_LANGUAGES } from '../../constants/languages';
+import { MEETING_URL } from '../../constants/urls';
 
 interface IndustryPageTemplateProps {
   title: string;
@@ -109,7 +110,7 @@ const IndustryPageTemplate: React.FC<IndustryPageTemplateProps> = ({
                      Sign Up
                   </a>
                   <a
-                    href="https://meetings.hubspot.com/seasalt-ai/seasalt-meeting/"
+                    href={MEETING_URL}
                     className={`border-2 ${borderColor} ${color} hover:${color.replace('text-', 'bg-')} hover:text-white px-8 py-4 rounded-lg text-lg font-semibold transition-all duration-200`}
                   >
                     See Demo
@@ -263,7 +264,7 @@ const IndustryPageTemplate: React.FC<IndustryPageTemplateProps> = ({
                  Sign Up
               </a>
               <a
-                href="https://meetings.hubspot.com/seasalt-ai/seasalt-meeting/"
+                href={MEETING_URL}
                 className="border-2 border-white text-white hover:bg-white hover:text-gray-800 px-8 py-4 rounded-lg text-lg font-semibold transition-all duration-200"
               >
                 Schedule Demo

--- a/src/pages/solutions/AIAutomation.tsx
+++ b/src/pages/solutions/AIAutomation.tsx
@@ -5,6 +5,7 @@ import Footer from '../../components/Footer';
 import SEOHelmet from '../../components/SEOHelmet';
 import { useTranslation } from 'react-i18next';
 import { SUPPORTED_LANGUAGES } from '../../constants/languages';
+import { MEETING_URL } from '../../constants/urls';
 
 const AIAutomation = () => {
   const { i18n } = useTranslation();
@@ -172,7 +173,7 @@ const AIAutomation = () => {
                     Start Automating
                   </a>
                   <a
-                    href="https://meetings.hubspot.com/seasalt-ai/seasalt-meeting/"
+                    href={MEETING_URL}
                     className="border-2 border-purple-600 text-purple-600 hover:bg-purple-600 hover:text-white px-8 py-4 rounded-lg text-lg font-semibold transition-all duration-200"
                   >
                     See AI in Action
@@ -422,7 +423,7 @@ const AIAutomation = () => {
                  Sign Up
               </a>
               <a
-                href="https://meetings.hubspot.com/seasalt-ai/seasalt-meeting/"
+                href={MEETING_URL}
                 className="border-2 border-white text-white hover:bg-white hover:text-purple-600 px-8 py-4 rounded-lg text-lg font-semibold transition-all duration-200"
               >
                 Book AI Demo

--- a/src/pages/solutions/CustomerSupport.tsx
+++ b/src/pages/solutions/CustomerSupport.tsx
@@ -5,6 +5,7 @@ import Footer from '../../components/Footer';
 import SEOHelmet from '../../components/SEOHelmet';
 import { useTranslation } from 'react-i18next';
 import { SUPPORTED_LANGUAGES } from '../../constants/languages';
+import { MEETING_URL } from '../../constants/urls';
 
 const CustomerSupport = () => {
   const { i18n } = useTranslation();
@@ -173,7 +174,7 @@ const CustomerSupport = () => {
                     Improve Support Now
                   </a>
                   <a
-                    href="https://meetings.hubspot.com/seasalt-ai/seasalt-meeting/"
+                    href={MEETING_URL}
                     className="border-2 border-blue-600 text-blue-600 hover:bg-blue-600 hover:text-white px-8 py-4 rounded-lg text-lg font-semibold transition-all duration-200"
                   >
                     See Demo
@@ -376,7 +377,7 @@ const CustomerSupport = () => {
                  Sign Up
               </a>
               <a
-                href="https://meetings.hubspot.com/seasalt-ai/seasalt-meeting/"
+                href={MEETING_URL}
                 className="border-2 border-white text-white hover:bg-white hover:text-blue-600 px-8 py-4 rounded-lg text-lg font-semibold transition-all duration-200"
               >
                 Book Support Demo

--- a/src/pages/solutions/SalesMarketing.tsx
+++ b/src/pages/solutions/SalesMarketing.tsx
@@ -5,6 +5,7 @@ import Footer from '../../components/Footer';
 import SEOHelmet from '../../components/SEOHelmet';
 import { useTranslation } from 'react-i18next';
 import { SUPPORTED_LANGUAGES } from '../../constants/languages';
+import { MEETING_URL } from '../../constants/urls';
 
 const SalesMarketing = () => {
   const { i18n } = useTranslation();
@@ -172,7 +173,7 @@ const SalesMarketing = () => {
                     Boost Your Conversions
                   </a>
                   <a
-                    href="https://meetings.hubspot.com/seasalt-ai/seasalt-meeting/" className="border-2 border-green-600 text-green-600 hover:bg-green-600 hover:text-white px-8 py-4 rounded-lg text-lg font-semibold transition-all duration-200"
+                    href={MEETING_URL} className="border-2 border-green-600 text-green-600 hover:bg-green-600 hover:text-white px-8 py-4 rounded-lg text-lg font-semibold transition-all duration-200"
                   >
                     Book A Demo
                   </a>
@@ -374,7 +375,7 @@ const SalesMarketing = () => {
                  Sign Up
               </a>
               <a
-                href="https://meetings.hubspot.com/seasalt-ai/seasalt-meeting/"
+                href={MEETING_URL}
                 className="border-2 border-white text-white hover:bg-white hover:text-green-600 px-8 py-4 rounded-lg text-lg font-semibold transition-all duration-200"
               >
                 Book Sales Demo

--- a/src/pages/solutions/SmeOwners.tsx
+++ b/src/pages/solutions/SmeOwners.tsx
@@ -5,6 +5,7 @@ import Footer from '../../components/Footer';
 import SEOHelmet from '../../components/SEOHelmet';
 import { useTranslation } from 'react-i18next';
 import { SUPPORTED_LANGUAGES } from '../../constants/languages';
+import { MEETING_URL } from '../../constants/urls';
 
 const SmeOwners = () => {
   const { i18n } = useTranslation();
@@ -172,7 +173,7 @@ const SmeOwners = () => {
                     Get Your AI Assistant
                   </a>
                   <a
-                     href="https://meetings.hubspot.com/seasalt-ai/seasalt-meeting/" className="border-2 border-blue-600 text-blue-600 hover:bg-blue-600 hover:text-white px-8 py-4 rounded-lg text-lg font-semibold transition-all duration-200"
+                     href={MEETING_URL} className="border-2 border-blue-600 text-blue-600 hover:bg-blue-600 hover:text-white px-8 py-4 rounded-lg text-lg font-semibold transition-all duration-200"
                   >
                     Book A Demo
                   </a>
@@ -374,7 +375,7 @@ const SmeOwners = () => {
                 Start Your Free Trial
               </a>
               <a
-                href="https://meetings.hubspot.com/seasalt-ai/seasalt-meeting/"
+                href={MEETING_URL}
                 className="border-2 border-white text-white hover:bg-white hover:text-blue-600 px-8 py-4 rounded-lg text-lg font-semibold transition-all duration-200"
               >
                 Schedule Personal Demo

--- a/src/seachat/components/FeatureComparison.tsx
+++ b/src/seachat/components/FeatureComparison.tsx
@@ -1,6 +1,9 @@
 import { useState } from 'react';
+import { MEETING_URL } from '../../constants/urls';
 import { Check, Star, AlertTriangle, X } from 'lucide-react';
+import { MEETING_URL } from '../../constants/urls';
 import { useTranslation } from 'react-i18next';
+import { MEETING_URL } from '../../constants/urls';
 
 const FeatureComparison = () => {
   const { t } = useTranslation();
@@ -410,7 +413,7 @@ const FeatureComparison = () => {
                 {t('seachat.featureComparison.startFree', 'Start Free Now')}
               </a>
               <a
-                href="https://meetings.hubspot.com/seasalt-ai/seasalt-meeting/"
+                href="{MEETING_URL}"
                 target="_blank"
                 rel="noopener noreferrer"
                 className="border-2 border-white text-white hover:bg-white hover:text-teal-600 px-8 py-4 rounded-lg text-lg font-semibold transition-all"

--- a/src/seachat/components/Footer.tsx
+++ b/src/seachat/components/Footer.tsx
@@ -1,9 +1,15 @@
 import { Twitter, Linkedin, Mail, Phone, MapPin, Youtube, Heart, Coffee, Umbrella, Plane, Gem, MessageSquare, Users, Shield, Bot, Brain, Database, BarChart3, Code, Globe, Settings, ShoppingCart, DollarSign, GraduationCap, Building2, Monitor, Briefcase, Book, Server, ChevronDown } from 'lucide-react';
+import { MEETING_URL } from '../../constants/urls';
 import { FaDiscord } from 'react-icons/fa';
+import { MEETING_URL } from '../../constants/urls';
 import { useTranslation } from 'react-i18next';
+import { MEETING_URL } from '../../constants/urls';
 import { Link } from 'react-router-dom';
+import { MEETING_URL } from '../../constants/urls';
 import { useState } from 'react';
+import { MEETING_URL } from '../../constants/urls';
 import { motion, AnimatePresence } from 'framer-motion';
+import { MEETING_URL } from '../../constants/urls';
 
 const Footer = () => {
   const { t, i18n } = useTranslation();
@@ -431,7 +437,7 @@ const Footer = () => {
               Sign Up Free
             </a>
             <a
-              href="https://meetings.hubspot.com/seasalt-ai/seasalt-meeting/"
+              href="{MEETING_URL}"
               className="border-2 border-white text-white hover:bg-white hover:text-teal-600 px-6 sm:px-8 py-2.5 sm:py-3 rounded-lg font-semibold transition-all duration-200 text-sm sm:text-base"
             >
               Schedule Demo

--- a/src/seachat/components/Hero.tsx
+++ b/src/seachat/components/Hero.tsx
@@ -1,14 +1,23 @@
 import { useState, useEffect } from 'react';
+import { MEETING_URL } from '../../constants/urls';
 import { RefreshCw } from 'lucide-react';
+import { MEETING_URL } from '../../constants/urls';
 import { useTranslation } from 'react-i18next';
+import { MEETING_URL } from '../../constants/urls';
 
 // Import all animation components
 import MultiChannelFlow from './hero-animations/MultiChannelFlow';
+import { MEETING_URL } from '../../constants/urls';
 import AgentToAI from './hero-animations/AgentToAI';
+import { MEETING_URL } from '../../constants/urls';
 import RealtimeDashboard from './hero-animations/RealtimeDashboard';
+import { MEETING_URL } from '../../constants/urls';
 import InteractiveChannels from './hero-animations/InteractiveChannels';
+import { MEETING_URL } from '../../constants/urls';
 import ConversationLearning from './hero-animations/ConversationLearning';
+import { MEETING_URL } from '../../constants/urls';
 import PhoneVoiceAI from './hero-animations/PhoneVoiceAI';
+import { MEETING_URL } from '../../constants/urls';
 
 const Hero = () => {
   const { t } = useTranslation();
@@ -176,7 +185,7 @@ const Hero = () => {
                   {t('seachat.hero.startFree')}
                 </button>
               </a>
-              <a href="https://meetings.hubspot.com/seasalt-ai/seasalt-meeting/" className="block">
+              <a href="{MEETING_URL}" className="block">
                 <button className="border-2 border-white text-white hover:bg-white hover:text-blue-900 px-8 py-4 rounded-lg text-lg font-semibold transition-all w-full">
                   {t('seachat.hero.exploreAI')}
                 </button>

--- a/src/seachat/components/UseCases.tsx
+++ b/src/seachat/components/UseCases.tsx
@@ -1,5 +1,7 @@
 import { TrendingUp } from 'lucide-react';
+import { MEETING_URL } from '../../constants/urls';
 import { useTranslation } from 'react-i18next';
+import { MEETING_URL } from '../../constants/urls';
 
 const UseCases = () => {
   const { t } = useTranslation();
@@ -149,7 +151,7 @@ const UseCases = () => {
                 Sign Up For Free
               </a>
               <a
-                href="https://meetings.hubspot.com/seasalt-ai/seasalt-meeting/"
+                href="{MEETING_URL}"
                 target="_blank"
                 rel="noopener noreferrer"
                 className="border-2 border-white text-white hover:bg-white hover:text-blue-600 px-8 py-4 rounded-lg font-semibold transition-all text-center"

--- a/src/seachat/pages/PricingPage.tsx
+++ b/src/seachat/pages/PricingPage.tsx
@@ -1,7 +1,11 @@
 import { useState } from 'react';
+import { MEETING_URL } from '../../constants/urls';
 import { Check, Zap, ArrowRight, MessageSquare, Bot, Users, Clock, Globe, Shield } from 'lucide-react';
+import { MEETING_URL } from '../../constants/urls';
 import { motion } from 'framer-motion';
+import { MEETING_URL } from '../../constants/urls';
 import SupportPlan from '../../components/SupportPlan';
+import { MEETING_URL } from '../../constants/urls';
 
 const PricingPage = () => {
   const [billingCycle, setBillingCycle] = useState<'monthly' | 'yearly'>('monthly');
@@ -736,7 +740,7 @@ const PricingPage = () => {
           </p>
           <div className="flex justify-center">
             <a 
-              href="https://meetings.hubspot.com/seasalt-ai/seasalt-meeting/" 
+              href="{MEETING_URL}" 
               target="_blank" 
               rel="noopener noreferrer"
               className="border-2 border-white text-white hover:bg-white hover:text-purple-600 px-8 py-4 rounded-lg text-lg font-semibold transition-all flex items-center justify-center"
@@ -897,7 +901,7 @@ const PricingPage = () => {
             </a>
             
             <a
-              href="https://meetings.hubspot.com/seasalt-ai/seasalt-meeting/"
+              href="{MEETING_URL}"
               className="inline-flex items-center px-8 py-4 text-xl font-semibold text-white border-2 border-white rounded-2xl hover:bg-white hover:text-indigo-900 transition-all duration-300 transform hover:scale-105"
             >
               <MessageSquare className="w-6 h-6 mr-3" />

--- a/src/seachat/pages/features/AIAutomationPage.tsx
+++ b/src/seachat/pages/features/AIAutomationPage.tsx
@@ -1,5 +1,7 @@
 import { Bot, Zap, Brain, MessageSquare, Clock, TrendingUp, ArrowRight } from 'lucide-react';
+import { MEETING_URL } from '../../../constants/urls';
 import { useTranslation } from 'react-i18next';
+import { MEETING_URL } from '../../../constants/urls';
 
 const AIAutomationPage = () => {
   const { t } = useTranslation();
@@ -95,7 +97,7 @@ const AIAutomationPage = () => {
                 {t('seachat.features.aiAutomation.tryButton', 'Try AI Automation')}
               </a>
               <a
-                href="https://meetings.hubspot.com/seasalt-ai/seasalt-meeting/"
+                href="{MEETING_URL}"
                 target="_blank"
                 rel="noopener noreferrer"
                 className="border-2 border-white text-white hover:bg-white hover:text-purple-900 px-8 py-4 rounded-lg text-lg font-semibold transition-all flex items-center justify-center"
@@ -255,7 +257,7 @@ const AIAutomationPage = () => {
               Sign Up For Free
             </a>
             <a
-              href="https://meetings.hubspot.com/seasalt-ai/seasalt-meeting/"
+              href="{MEETING_URL}"
               target="_blank"
               rel="noopener noreferrer"
               className="border-2 border-white text-white hover:bg-white hover:text-purple-600 px-8 py-4 rounded-lg text-lg font-semibold transition-all flex items-center justify-center"

--- a/src/seachat/pages/features/AdvancedAIPage.tsx
+++ b/src/seachat/pages/features/AdvancedAIPage.tsx
@@ -1,5 +1,7 @@
 import { Brain, Search, Clock, Target, FileText, Database, Zap, Star, ArrowRight } from 'lucide-react';
+import { MEETING_URL } from '../../../constants/urls';
 import { useTranslation } from 'react-i18next';
+import { MEETING_URL } from '../../../constants/urls';
 
 const AdvancedAIPage = () => {
   const { t } = useTranslation();
@@ -127,7 +129,7 @@ const AdvancedAIPage = () => {
                 {t('seachat.features.advancedAI.exploreButton', 'Explore Advanced AI')}
               </a>
               <a
-                href="https://meetings.hubspot.com/seasalt-ai/seasalt-meeting/"
+                href="{MEETING_URL}"
                 target="_blank"
                 rel="noopener noreferrer"
                 className="border-2 border-white text-white hover:bg-white hover:text-purple-900 px-8 py-4 rounded-lg text-lg font-semibold transition-all text-center"
@@ -308,7 +310,7 @@ const AdvancedAIPage = () => {
               Sign Up For Free
             </a>
             <a
-              href="https://meetings.hubspot.com/seasalt-ai/seasalt-meeting/"
+              href="{MEETING_URL}"
               target="_blank"
               rel="noopener noreferrer"
               className="border-2 border-white text-white hover:bg-white hover:text-purple-600 px-8 py-4 rounded-lg text-lg font-semibold transition-all flex items-center justify-center"

--- a/src/seachat/pages/features/AnalyticsPage.tsx
+++ b/src/seachat/pages/features/AnalyticsPage.tsx
@@ -1,5 +1,7 @@
 import { BarChart3, TrendingUp, Users, Clock, Target, Eye } from 'lucide-react';
+import { MEETING_URL } from '../../../constants/urls';
 import { useTranslation } from 'react-i18next';
+import { MEETING_URL } from '../../../constants/urls';
 
 const AnalyticsPage = () => {
   const { t } = useTranslation();
@@ -107,7 +109,7 @@ const AnalyticsPage = () => {
                 Sign Up For Free
               </a>
               <a
-                href="https://meetings.hubspot.com/seasalt-ai/seasalt-meeting/"
+                href="{MEETING_URL}"
                 target="_blank"
                 rel="noopener noreferrer"
                 className="border-2 border-white text-white hover:bg-white hover:text-blue-900 px-8 py-4 rounded-lg text-lg font-semibold transition-all text-center"
@@ -271,7 +273,7 @@ const AnalyticsPage = () => {
               Sign Up For Free
             </a>
             <a
-              href="https://meetings.hubspot.com/seasalt-ai/seasalt-meeting/"
+              href="{MEETING_URL}"
               target="_blank"
               rel="noopener noreferrer"
               className="border-2 border-white text-white hover:bg-white hover:text-blue-600 px-8 py-4 rounded-lg text-lg font-semibold transition-all flex items-center justify-center text-center"

--- a/src/seachat/pages/features/HumanAgentsPage.tsx
+++ b/src/seachat/pages/features/HumanAgentsPage.tsx
@@ -1,5 +1,7 @@
 import { Users, MessageCircle, Shield, Star, CheckCircle, Infinity, Heart, Coffee } from 'lucide-react';
+import { MEETING_URL } from '../../../constants/urls';
 import { useTranslation } from 'react-i18next';
+import { MEETING_URL } from '../../../constants/urls';
 
 const HumanAgentsPage = () => {
   const { t } = useTranslation();
@@ -226,7 +228,7 @@ const HumanAgentsPage = () => {
                 {t('seachat.features.humanAgents.ctaStartButton', 'Start Free Now')}
             </a>
             <a
-              href="https://meetings.hubspot.com/seasalt-ai/seasalt-meeting/"
+              href="{MEETING_URL}"
               target="_blank"
               rel="noopener noreferrer"
               className="border-2 border-white text-white hover:bg-white hover:text-blue-600 px-8 py-4 rounded-lg text-lg font-semibold transition-all"

--- a/src/seachat/pages/features/OmnichannelPage.tsx
+++ b/src/seachat/pages/features/OmnichannelPage.tsx
@@ -1,5 +1,7 @@
 import { Globe, MessageSquare, Phone, Mail, Instagram, Facebook, ArrowRight } from 'lucide-react';
+import { MEETING_URL } from '../../../constants/urls';
 import { useTranslation } from 'react-i18next';
+import { MEETING_URL } from '../../../constants/urls';
 
 const OmnichannelPage = () => {
   const { t } = useTranslation();
@@ -121,7 +123,7 @@ const OmnichannelPage = () => {
                 Sign Up For Free
               </a>
               <a
-                href="https://meetings.hubspot.com/seasalt-ai/seasalt-meeting/"
+                href="{MEETING_URL}"
                 target="_blank"
                 rel="noopener noreferrer"
                 className="border-2 border-white text-white hover:bg-white hover:text-purple-900 px-8 py-4 rounded-lg text-lg font-semibold transition-all text-center"
@@ -290,7 +292,7 @@ const OmnichannelPage = () => {
               Sign Up For Free
             </a>
             <a
-              href="https://meetings.hubspot.com/seasalt-ai/seasalt-meeting/"
+              href="{MEETING_URL}"
               target="_blank"
               rel="noopener noreferrer"
               className="border-2 border-white text-white hover:bg-white hover:text-purple-600 px-8 py-4 rounded-lg text-lg font-semibold transition-all flex items-center justify-center text-center"

--- a/src/seachat/pages/features/VoiceAgentsPage.tsx
+++ b/src/seachat/pages/features/VoiceAgentsPage.tsx
@@ -1,5 +1,7 @@
 import { Phone, Mic, Volume2, Clock, Globe, Brain, ArrowRight, Play } from 'lucide-react';
+import { MEETING_URL } from '../../../constants/urls';
 import { useTranslation } from 'react-i18next';
+import { MEETING_URL } from '../../../constants/urls';
 
 const VoiceAgentsPage = () => {
   const { t } = useTranslation();
@@ -108,7 +110,7 @@ const VoiceAgentsPage = () => {
                 Sign Up For Free
               </a>
               <a
-                href="https://meetings.hubspot.com/seasalt-ai/seasalt-meeting/"
+                href="{MEETING_URL}"
                 target="_blank"
                 rel="noopener noreferrer"
                 className="border-2 border-white text-white hover:bg-white hover:text-indigo-900 px-8 py-4 rounded-lg text-lg font-semibold transition-all flex items-center justify-center text-center"
@@ -278,7 +280,7 @@ const VoiceAgentsPage = () => {
               Sign Up For Free
             </a>
             <a
-              href="https://meetings.hubspot.com/seasalt-ai/seasalt-meeting/"
+              href="{MEETING_URL}"
               target="_blank"
               rel="noopener noreferrer"
               className="border-2 border-white text-white hover:bg-white hover:text-indigo-600 px-8 py-4 rounded-lg text-lg font-semibold transition-all flex items-center justify-center text-center"

--- a/src/seachat/pages/integrations/CalendarPage.tsx
+++ b/src/seachat/pages/integrations/CalendarPage.tsx
@@ -1,5 +1,7 @@
 import { Calendar, Clock, Users, Video, CheckCircle, ArrowRight } from 'lucide-react';
+import { MEETING_URL } from '../../../constants/urls';
 import { useTranslation } from 'react-i18next';
+import { MEETING_URL } from '../../../constants/urls';
 
 const CalendarPage = () => {
   const { t } = useTranslation();
@@ -211,7 +213,7 @@ const CalendarPage = () => {
                 {t('seachat.integrations.calendar.connectButton', 'Connect Calendar')}
               </a>
               <a
-                href="https://meetings.hubspot.com/seasalt-ai/seasalt-meeting/"
+                href="{MEETING_URL}"
                 target="_blank"
                 rel="noopener noreferrer"
                 className="border-2 border-white text-white hover:bg-white hover:text-blue-900 px-8 py-4 rounded-lg text-lg font-semibold transition-all text-center"

--- a/src/seachat/pages/integrations/CommunicationPage.tsx
+++ b/src/seachat/pages/integrations/CommunicationPage.tsx
@@ -1,6 +1,9 @@
 import { Mail, MessageSquare, Video, Slack, CheckCircle } from 'lucide-react';
+import { MEETING_URL } from '../../../constants/urls';
 import { SiWhatsapp, SiKakaotalk, SiGooglechat, SiZalo } from 'react-icons/si';
+import { MEETING_URL } from '../../../constants/urls';
 import { useTranslation } from 'react-i18next';
+import { MEETING_URL } from '../../../constants/urls';
 
 const CommunicationPage = () => {
   const { t } = useTranslation();
@@ -201,7 +204,7 @@ const CommunicationPage = () => {
                 {t('seachat.integrations.communication.connectButton', 'Connect Communication Tools')}
               </a>
               <a
-                href="https://meetings.hubspot.com/seasalt-ai/seasalt-meeting/"
+                href="{MEETING_URL}"
                 target="_blank"
                 rel="noopener noreferrer"
                 className="border-2 border-white text-white hover:bg-white hover:text-indigo-900 px-8 py-4 rounded-lg text-lg font-semibold transition-all inline-block"
@@ -344,7 +347,7 @@ const CommunicationPage = () => {
               {t('seachat.integrations.communication.cta.connectButton', 'Get Started Now')}
             </a>
             <a
-              href="https://meetings.hubspot.com/seasalt-ai/seasalt-meeting/"
+              href="{MEETING_URL}"
               target="_blank"
               rel="noopener noreferrer"
               className="border-2 border-white text-white hover:bg-white hover:text-indigo-900 px-8 py-4 rounded-lg text-lg font-semibold transition-all inline-block text-center"

--- a/src/seachat/pages/integrations/EcommercePage.tsx
+++ b/src/seachat/pages/integrations/EcommercePage.tsx
@@ -1,5 +1,7 @@
 import { ShoppingBag, TrendingUp, Package, CreditCard, CheckCircle } from 'lucide-react';
+import { MEETING_URL } from '../../../constants/urls';
 import { useTranslation } from 'react-i18next';
+import { MEETING_URL } from '../../../constants/urls';
 
 const EcommercePage = () => {
   const { t } = useTranslation();
@@ -251,7 +253,7 @@ const EcommercePage = () => {
               <a href="https://chat.seasalt.ai/gpt/signup" className="bg-blue-600 text-white px-6 py-3 rounded-lg text-lg font-semibold hover:bg-blue-700 transition duration-300">
                 {t('seachat.integrations.ecommerce.hero.button1', 'Connect Your Store')}
               </a>
-              <a href="https://meetings.hubspot.com/seasalt-ai/seasalt-meeting/" className="bg-blue-600 text-white px-6 py-3 rounded-lg text-lg font-semibold hover:bg-blue-700 transition duration-300">
+              <a href="{MEETING_URL}" className="bg-blue-600 text-white px-6 py-3 rounded-lg text-lg font-semibold hover:bg-blue-700 transition duration-300">
                 {t('seachat.integrations.ecommerce.hero.button2', 'Schedule E-commerce Demo')}
               </a>
             </div>
@@ -407,7 +409,7 @@ const EcommercePage = () => {
           <a href="https://chat.seasalt.ai/gpt/signup" className="bg-blue-600 text-white px-8 py-4 rounded-lg text-xl font-semibold hover:bg-blue-700 transition duration-300">
             {t('seachat.integrations.ecommerce.cta.button1', 'Connect Your Store Now')}
           </a>
-          <a href="https://meetings.hubspot.com/seasalt-ai/seasalt-meeting/" className="bg-blue-600 text-white px-8 py-4 rounded-lg text-xl font-semibold hover:bg-blue-700 transition duration-300">
+          <a href="{MEETING_URL}" className="bg-blue-600 text-white px-8 py-4 rounded-lg text-xl font-semibold hover:bg-blue-700 transition duration-300">
             {t('seachat.integrations.ecommerce.cta.button2', 'Schedule E-commerce Demo')}
           </a>
           </div>

--- a/src/seachat/pages/integrations/MarketingPage.tsx
+++ b/src/seachat/pages/integrations/MarketingPage.tsx
@@ -1,8 +1,11 @@
 
 import { SiMailchimp, SiHubspot } from 'react-icons/si';
+import { MEETING_URL } from '../../../constants/urls';
 import { Mail, Target, Users, Zap, ArrowRight, CheckCircle } from 'lucide-react';
+import { MEETING_URL } from '../../../constants/urls';
 
 import { useTranslation } from 'react-i18next';
+import { MEETING_URL } from '../../../constants/urls';
 
 const MarketingPage = () => {
   const { t } = useTranslation();
@@ -210,7 +213,7 @@ const MarketingPage = () => {
                 {t('seachat.integrations.marketing.connectButton', 'Connect Marketing Tools')}
               </a>
               <a
-                href="https://meetings.hubspot.com/seasalt-ai/seasalt-meeting/"
+                href="{MEETING_URL}"
                 target="_blank"
                 rel="noopener noreferrer"
                 className="border-2 border-white text-white hover:bg-white hover:text-orange-900 px-8 py-4 rounded-lg text-lg font-semibold transition-all text-center"

--- a/src/seachat/pages/integrations/SocialMediaPage.tsx
+++ b/src/seachat/pages/integrations/SocialMediaPage.tsx
@@ -1,6 +1,9 @@
 import { MessageSquare, Instagram, Facebook, ArrowRight, CheckCircle } from 'lucide-react';
+import { MEETING_URL } from '../../../constants/urls';
 import { SiTiktok, SiLine, SiWhatsapp, SiX } from 'react-icons/si';
+import { MEETING_URL } from '../../../constants/urls';
 import { useTranslation } from 'react-i18next';
+import { MEETING_URL } from '../../../constants/urls';
 
 const SocialMediaPage = () => {
   const { t } = useTranslation();
@@ -137,7 +140,7 @@ const SocialMediaPage = () => {
               <a href="https://chat.seasalt.ai/gpt/signup" className="bg-pink-500 hover:bg-pink-400 text-white px-8 py-4 rounded-lg text-lg font-semibold transition-all transform hover:scale-105 text-center">
                 {t('seachat.integrations.social.connectButton', 'Connect Social Platforms')}
               </a>
-              <a href="https://meetings.hubspot.com/seasalt-ai/seasalt-meeting/" className="border-2 border-white text-white hover:bg-white hover:text-pink-900 px-8 py-4 rounded-lg text-lg font-semibold transition-all text-center">
+              <a href="{MEETING_URL}" className="border-2 border-white text-white hover:bg-white hover:text-pink-900 px-8 py-4 rounded-lg text-lg font-semibold transition-all text-center">
                 {t('seachat.integrations.social.demoButton', 'Schedule Social Demo')}
               </a>
             </div>
@@ -302,7 +305,7 @@ const SocialMediaPage = () => {
             <a href="https://chat.seasalt.ai/gpt/signup" className="bg-white text-pink-600 hover:bg-gray-100 px-8 py-4 rounded-lg text-lg font-semibold transition-colors text-center">
               {t('seachat.integrations.social.ctaConnectButton', 'Connect Social Platforms')}
             </a>
-            <a href="https://meetings.hubspot.com/seasalt-ai/seasalt-meeting/" className="border-2 border-white text-white hover:bg-white hover:text-pink-600 px-8 py-4 rounded-lg text-lg font-semibold transition-all flex items-center justify-center text-center">
+            <a href="{MEETING_URL}" className="border-2 border-white text-white hover:bg-white hover:text-pink-600 px-8 py-4 rounded-lg text-lg font-semibold transition-all flex items-center justify-center text-center">
               {t('seachat.integrations.social.ctaGuideButton', 'Schedule E-commerce Demo')}
               <ArrowRight className="w-5 h-5 ml-2" />
             </a>

--- a/src/seachat/pages/integrations/WebsitesPage.tsx
+++ b/src/seachat/pages/integrations/WebsitesPage.tsx
@@ -1,6 +1,9 @@
 import { Globe, Zap, CheckCircle, ArrowRight, Copy, ExternalLink } from 'lucide-react';
+import { MEETING_URL } from '../../../constants/urls';
 import { SiWordpress, SiShopify, SiWix, SiSquarespace, SiWebflow } from 'react-icons/si';
+import { MEETING_URL } from '../../../constants/urls';
 import { useTranslation } from 'react-i18next';
+import { MEETING_URL } from '../../../constants/urls';
 
 const WebsitesPage = () => {
   const { t } = useTranslation();
@@ -150,7 +153,7 @@ const WebsitesPage = () => {
               <a href="https://chat.seasalt.ai/gpt/signup" className="bg-blue-500 hover:bg-blue-400 text-white px-8 py-4 rounded-lg text-lg font-semibold transition-all transform hover:scale-105 flex items-center justify-center">
                 {t('seachat.integrations.websites.codeButton', 'Get Widget Code')}
               </a>
-              <a href="https://meetings.hubspot.com/seasalt-ai/seasalt-meeting/" className="border-2 border-white text-white hover:bg-white hover:text-blue-900 px-8 py-4 rounded-lg text-lg font-semibold transition-all flex items-center justify-center">
+              <a href="{MEETING_URL}" className="border-2 border-white text-white hover:bg-white hover:text-blue-900 px-8 py-4 rounded-lg text-lg font-semibold transition-all flex items-center justify-center">
                 {t('seachat.integrations.websites.demoButton', 'Schedule Demo')}
               </a>
             </div>

--- a/src/seachat/pages/solutions/EcommerceSolutionPage.tsx
+++ b/src/seachat/pages/solutions/EcommerceSolutionPage.tsx
@@ -1,5 +1,7 @@
 import { ShoppingBag, TrendingUp, Clock, Users, Star, ArrowRight, CheckCircle } from 'lucide-react';
+import { MEETING_URL } from '../../../constants/urls';
 import { useTranslation } from 'react-i18next';
+import { MEETING_URL } from '../../../constants/urls';
 
 const EcommerceSolutionPage = () => {
   const { t } = useTranslation();
@@ -132,7 +134,7 @@ const EcommerceSolutionPage = () => {
               {t('seachat.solutions.ecommerce.trialButton', 'Start E-commerce For Free')}
             </a>
             <a
-              href="https://meetings.hubspot.com/seasalt-ai/seasalt-meeting/"
+              href="{MEETING_URL}"
               target="_blank"
               rel="noopener noreferrer"
               className="border-2 border-white text-white hover:bg-white hover:text-purple-900 px-8 py-4 rounded-lg text-lg font-semibold transition-all text-center"
@@ -327,7 +329,7 @@ const EcommerceSolutionPage = () => {
               {t('seachat.solutions.ecommerce.ctaTrialButton', 'Start E-commerce For Free')}
             </a>
             <a
-              href="https://meetings.hubspot.com/seasalt-ai/seasalt-meeting/"
+              href="{MEETING_URL}"
               target="_blank"
               rel="noopener noreferrer"
               className="border-2 border-white text-white hover:bg-white hover:text-purple-600 px-8 py-4 rounded-lg text-lg font-semibold transition-all flex items-center justify-center text-center"

--- a/src/seachat/pages/solutions/EducationPage.tsx
+++ b/src/seachat/pages/solutions/EducationPage.tsx
@@ -1,5 +1,7 @@
 import { GraduationCap, BookOpen, Users, Calendar, MessageSquare, ArrowRight, CheckCircle } from 'lucide-react';
+import { MEETING_URL } from '../../../constants/urls';
 import { useTranslation } from 'react-i18next';
+import { MEETING_URL } from '../../../constants/urls';
 
 const EducationPage = () => {
   const { t } = useTranslation();
@@ -204,7 +206,7 @@ const EducationPage = () => {
                 {t('seachat.solutions.education.trialButton', 'Start Education For Free')}
               </a>
               <a
-                href="https://meetings.hubspot.com/seasalt-ai/seasalt-meeting/"
+                href="{MEETING_URL}"
                 target="_blank"
                 rel="noopener noreferrer"
                 className="border-2 border-white text-white hover:bg-white hover:text-blue-900 px-8 py-4 rounded-lg text-lg font-semibold transition-all text-center"
@@ -403,7 +405,7 @@ const EducationPage = () => {
               {t('seachat.solutions.education.ctaTrialButton', 'Start Education For Free')}
             </a>
             <a
-              href="https://meetings.hubspot.com/seasalt-ai/seasalt-meeting/"
+              href="{MEETING_URL}"
               target="_blank"
               rel="noopener noreferrer"
               className="border-2 border-white text-white hover:bg-white hover:text-blue-600 px-8 py-4 rounded-lg text-lg font-semibold transition-all flex items-center justify-center text-center"

--- a/src/seachat/pages/solutions/FintechPage.tsx
+++ b/src/seachat/pages/solutions/FintechPage.tsx
@@ -1,5 +1,7 @@
 import { DollarSign, Shield, TrendingUp, CreditCard, Lock, ArrowRight, CheckCircle } from 'lucide-react';
+import { MEETING_URL } from '../../../constants/urls';
 import { useTranslation } from 'react-i18next';
+import { MEETING_URL } from '../../../constants/urls';
 
 const FintechPage = () => {
   const { t } = useTranslation();
@@ -162,7 +164,7 @@ const FintechPage = () => {
                 {t('seachat.solutions.fintech.trialButton', 'Start Fintech For Free')}
               </a>
               <a
-                href="https://meetings.hubspot.com/seasalt-ai/seasalt-meeting/"
+                href="{MEETING_URL}"
                 target="_blank"
                 rel="noopener noreferrer"
                 className="border-2 border-white text-white hover:bg-white hover:text-green-900 px-8 py-4 rounded-lg text-lg font-semibold transition-all text-center"
@@ -350,7 +352,7 @@ const FintechPage = () => {
               {t('seachat.solutions.fintech.ctaTrialButton', 'Start Fintech For Free')}
             </a>
             <a
-              href="https://meetings.hubspot.com/seasalt-ai/seasalt-meeting/"
+              href="{MEETING_URL}"
               target="_blank"
               rel="noopener noreferrer"
               className="border-2 border-white text-white hover:bg-white hover:text-green-600 px-8 py-4 rounded-lg text-lg font-semibold transition-all flex items-center justify-center text-center"

--- a/src/seachat/pages/solutions/HealthcarePage.tsx
+++ b/src/seachat/pages/solutions/HealthcarePage.tsx
@@ -1,5 +1,7 @@
 import { Heart, Shield, Users, Phone, Calendar, ArrowRight, CheckCircle } from 'lucide-react';
+import { MEETING_URL } from '../../../constants/urls';
 import { useTranslation } from 'react-i18next';
+import { MEETING_URL } from '../../../constants/urls';
 
 const HealthcarePage = () => {
   const { t } = useTranslation();
@@ -128,7 +130,7 @@ const HealthcarePage = () => {
                 {t('seachat.solutions.healthcare.trialButton', 'Start Healthcare For Free')}
               </a>
               <a
-                href="https://meetings.hubspot.com/seasalt-ai/seasalt-meeting/"
+                href="{MEETING_URL}"
                 target="_blank"
                 rel="noopener noreferrer"
                 className="border-2 border-white text-white hover:bg-white hover:text-teal-900 px-8 py-4 rounded-lg text-lg font-semibold transition-all text-center"
@@ -320,7 +322,7 @@ const HealthcarePage = () => {
               {t('seachat.solutions.healthcare.ctaTrialButton', 'Start Healthcare For Free')}
             </a>
             <a
-              href="https://meetings.hubspot.com/seasalt-ai/seasalt-meeting/"
+              href="{MEETING_URL}"
               target="_blank"
               rel="noopener noreferrer"
               className="border-2 border-white text-white hover:bg-white hover:text-teal-600 px-8 py-4 rounded-lg text-lg font-semibold transition-all flex items-center justify-center text-center"

--- a/src/seachat/pages/solutions/RealEstatePage.tsx
+++ b/src/seachat/pages/solutions/RealEstatePage.tsx
@@ -1,5 +1,7 @@
 import { Home, Calendar, Users, Phone, Search, ArrowRight, CheckCircle } from 'lucide-react';
+import { MEETING_URL } from '../../../constants/urls';
 import { useTranslation } from 'react-i18next';
+import { MEETING_URL } from '../../../constants/urls';
 
 const RealEstatePage = () => {
   const { t } = useTranslation();
@@ -156,7 +158,7 @@ const RealEstatePage = () => {
                 {t('seachat.solutions.realEstate.trialButton', 'Start Real Estate For Free')}
               </a>
               <a
-                href="https://meetings.hubspot.com/seasalt-ai/seasalt-meeting/"
+                href="{MEETING_URL}"
                 target="_blank"
                 rel="noopener noreferrer"
                 className="border-2 border-white text-white hover:bg-white hover:text-blue-900 px-8 py-4 rounded-lg text-lg font-semibold transition-all text-center"
@@ -370,7 +372,7 @@ const RealEstatePage = () => {
               {t('seachat.solutions.realEstate.ctaTrialButton', 'Start Real Estate For Free')}
             </a>
             <a
-              href="https://meetings.hubspot.com/seasalt-ai/seasalt-meeting/"
+              href="{MEETING_URL}"
               target="_blank"
               rel="noopener noreferrer"
               className="border-2 border-white text-white hover:bg-white hover:text-blue-600 px-8 py-4 rounded-lg text-lg font-semibold transition-all flex items-center justify-center text-center"

--- a/src/seachat/pages/solutions/SaaSPage.tsx
+++ b/src/seachat/pages/solutions/SaaSPage.tsx
@@ -1,5 +1,7 @@
 import { Cloud, Code, Users, TrendingUp, Shield, ArrowRight, CheckCircle } from 'lucide-react';
+import { MEETING_URL } from '../../../constants/urls';
 import { useTranslation } from 'react-i18next';
+import { MEETING_URL } from '../../../constants/urls';
 
 const SaaSPage = () => {
   const { t } = useTranslation();
@@ -192,7 +194,7 @@ const SaaSPage = () => {
               {t('seachat.solutions.saas.trialButton', 'Start SaaS For Free')}
             </a>
             <a
-              href="https://meetings.hubspot.com/seasalt-ai/seasalt-meeting/"
+              href="{MEETING_URL}"
               target="_blank"
               rel="noopener noreferrer"
               className="border-2 border-white text-white hover:bg-white hover:text-indigo-900 px-8 py-4 rounded-lg text-lg font-semibold transition-all text-center"
@@ -427,7 +429,7 @@ const SaaSPage = () => {
               {t('seachat.solutions.saas.ctaTrialButton', 'Start SaaS For Free')}
             </a>
             <a
-              href="https://meetings.hubspot.com/seasalt-ai/seasalt-meeting/"
+              href="{MEETING_URL}"
               target="_blank"
               rel="noopener noreferrer"
               className="border-2 border-white text-white hover:bg-white hover:text-indigo-600 px-8 py-4 rounded-lg text-lg font-semibold transition-all flex items-center justify-center text-center"

--- a/src/seachat/pages/solutions/SmallBusinessPage.tsx
+++ b/src/seachat/pages/solutions/SmallBusinessPage.tsx
@@ -1,5 +1,7 @@
 import { Store, Users, DollarSign, Clock, ArrowRight, CheckCircle } from 'lucide-react';
+import { MEETING_URL } from '../../../constants/urls';
 import { useTranslation } from 'react-i18next';
+import { MEETING_URL } from '../../../constants/urls';
 
 const SmallBusinessPage = () => {
   const { t } = useTranslation();
@@ -438,7 +440,7 @@ const SmallBusinessPage = () => {
               {t('seachat.solutions.smallBusiness.ctaStartButton', 'Start Small Business For Free')}
             </a>
             <a
-              href="https://meetings.hubspot.com/seasalt-ai/seasalt-meeting/"
+              href="{MEETING_URL}"
               target="_blank"
               rel="noopener noreferrer"
               className="border-2 border-white text-white hover:bg-white hover:text-green-600 px-8 py-4 rounded-lg text-lg font-semibold transition-all flex items-center justify-center text-center"

--- a/src/seachat/pages/solutions/TravelPage.tsx
+++ b/src/seachat/pages/solutions/TravelPage.tsx
@@ -1,5 +1,7 @@
 import { Plane, MapPin, Calendar, Clock, ArrowRight, CheckCircle } from 'lucide-react';
+import { MEETING_URL } from '../../../constants/urls';
 import { useTranslation } from 'react-i18next';
+import { MEETING_URL } from '../../../constants/urls';
 
 const TravelPage = () => {
   const { t } = useTranslation();
@@ -192,7 +194,7 @@ const TravelPage = () => {
               {t('seachat.solutions.travel.trialButton', 'Start Travel For Free')}
             </a>
             <a
-              href="https://meetings.hubspot.com/seasalt-ai/seasalt-meeting/"
+              href="{MEETING_URL}"
               target="_blank"
               rel="noopener noreferrer"
               className="border-2 border-white text-white hover:bg-white hover:text-cyan-900 px-8 py-4 rounded-lg text-lg font-semibold transition-all text-center"
@@ -427,7 +429,7 @@ const TravelPage = () => {
               {t('seachat.solutions.travel.ctaTrialButton', 'Start Travel For Free')}
             </a>
             <a
-              href="https://meetings.hubspot.com/seasalt-ai/seasalt-meeting/"
+              href="{MEETING_URL}"
               target="_blank"
               rel="noopener noreferrer"
               className="border-2 border-white text-white hover:bg-white hover:text-cyan-600 px-8 py-4 rounded-lg text-lg font-semibold transition-all flex items-center justify-center text-center"

--- a/src/seavoice/components/Footer.tsx
+++ b/src/seavoice/components/Footer.tsx
@@ -1,9 +1,15 @@
 import { Link } from 'react-router-dom';
+import { MEETING_URL } from '../../constants/urls';
 import { Linkedin, Twitter, Youtube, Mail, Phone, MapPin, Heart, Coffee, Umbrella, Plane, Gem, PhoneCall, Users, Activity, Monitor, Wifi, MessageSquare, Mic, MicOff, Brain, Bot, ArrowRightLeft, Zap, Shield, Headphones, Package, CreditCard, Calendar, Target, DollarSign, UserCheck, Clock, Megaphone, Headset, RefreshCw, BarChart3, Book, Server, Briefcase, Building2, ChevronDown } from 'lucide-react';
+import { MEETING_URL } from '../../constants/urls';
 import { FaDiscord } from 'react-icons/fa';
+import { MEETING_URL } from '../../constants/urls';
 import { useTranslation } from 'react-i18next';
+import { MEETING_URL } from '../../constants/urls';
 import { useState } from 'react';
+import { MEETING_URL } from '../../constants/urls';
 import { motion, AnimatePresence } from 'framer-motion';
+import { MEETING_URL } from '../../constants/urls';
 
 
 const Footer = () => {
@@ -446,7 +452,7 @@ const Footer = () => {
               Get Started Free
             </a>
             <a
-              href="https://meetings.hubspot.com/seasalt-ai/seasalt-meeting/"
+              href={MEETING_URL}
               className="border-2 border-white text-white hover:bg-white hover:text-blue-600 px-6 sm:px-8 py-2.5 sm:py-3 rounded-lg font-semibold transition-all duration-200 text-sm sm:text-base"
             >
               Book a Demo

--- a/src/seavoice/components/PriceCalculator.tsx
+++ b/src/seavoice/components/PriceCalculator.tsx
@@ -1,6 +1,9 @@
 import { useState } from 'react';
+import { MEETING_URL } from '../../constants/urls';
 import { motion } from 'framer-motion';
+import { MEETING_URL } from '../../constants/urls';
 import { Calculator, Phone, Clock, Users } from 'lucide-react';
+import { MEETING_URL } from '../../constants/urls';
 
 const PriceCalculator = () => {
   const [planType, setPlanType] = useState<'inbound' | 'inbound-outbound'>('inbound');
@@ -257,7 +260,7 @@ const PriceCalculator = () => {
                   Get Started with {planType === 'inbound' ? 'Inbound Only' : 'Inbound + Outbound'}
                 </a>
                 <a
-                  href="https://meetings.hubspot.com/seasalt-ai/seasalt-meeting"
+                  href={MEETING_URL}
                   target="_blank"
                   rel="noopener noreferrer"
                   className="w-full py-4 px-6 rounded-lg font-semibold text-gray-700 bg-white border-2 border-gray-300 text-center inline-block transition-all hover:border-gray-400"

--- a/src/seavoice/components/hero-variants/IndustryShowcaseCarousel.tsx
+++ b/src/seavoice/components/hero-variants/IndustryShowcaseCarousel.tsx
@@ -1,6 +1,9 @@
 import { useState, useEffect } from 'react';
+import { MEETING_URL } from '../../../constants/urls';
 import { motion, AnimatePresence } from 'framer-motion';
+import { MEETING_URL } from '../../../constants/urls';
 import { Utensils, Building, Heart, ChevronLeft, ChevronRight, ArrowRight, Star, TrendingUp } from 'lucide-react';
+import { MEETING_URL } from '../../../constants/urls';
 
 const IndustryShowcaseCarousel = () => {
   const showcases = [
@@ -163,7 +166,7 @@ const IndustryShowcaseCarousel = () => {
                 {/* CTA Buttons */}
                 <div className="flex flex-col sm:flex-row gap-4">
                   <motion.a
-                    href="https://meetings.hubspot.com/seasalt-ai/seasalt-meeting"
+                    href={MEETING_URL}
                     target="_blank"
                     rel="noopener noreferrer"
                     whileHover={{ scale: 1.05 }}

--- a/src/seavoice/components/hero-variants/InteractiveCallDashboard.tsx
+++ b/src/seavoice/components/hero-variants/InteractiveCallDashboard.tsx
@@ -1,6 +1,9 @@
 import { useState, useEffect } from 'react';
+import { MEETING_URL } from '../../../constants/urls';
 import { motion, AnimatePresence } from 'framer-motion';
+import { MEETING_URL } from '../../../constants/urls';
 import { Phone, Users, Clock, BarChart3, Globe, ArrowRight, Activity } from 'lucide-react';
+import { MEETING_URL } from '../../../constants/urls';
 
 const InteractiveCallDashboard = () => {
   const [activeCalls, setActiveCalls] = useState(247);
@@ -99,7 +102,7 @@ const InteractiveCallDashboard = () => {
 
             <div className="flex flex-col sm:flex-row gap-4">
               <motion.a
-                href="https://meetings.hubspot.com/seasalt-ai/seasalt-meeting"
+                href={MEETING_URL}
                 target="_blank"
                 rel="noopener noreferrer"
                 whileHover={{ scale: 1.05 }}

--- a/src/seavoice/pages/HomePage.tsx
+++ b/src/seavoice/pages/HomePage.tsx
@@ -1,8 +1,13 @@
 import { motion } from 'framer-motion';
+import { MEETING_URL } from '../../constants/urls';
 import { Phone, Brain, BarChart3, CheckCircle, ArrowRight, Star, Bot, Users, Headphones } from 'lucide-react';
+import { MEETING_URL } from '../../constants/urls';
 import VoiceDemo from '../components/VoiceDemo';
+import { MEETING_URL } from '../../constants/urls';
 import VoiceConversationFlow from '../components/hero-variants/VoiceConversationFlow';
+import { MEETING_URL } from '../../constants/urls';
 import InteractiveCallDashboard from '../components/hero-variants/InteractiveCallDashboard';
+import { MEETING_URL } from '../../constants/urls';
 
 const HomePage = () => {
 
@@ -350,7 +355,7 @@ const HomePage = () => {
               Get a personalized demo and discover how SeaVoice can transform your customer communications
             </p>
             <a
-              href="https://meetings.hubspot.com/seasalt-ai/seasalt-meeting"
+              href={MEETING_URL}
               target="_blank"
               rel="noopener noreferrer"
             >

--- a/src/seavoice/pages/PricingPage.tsx
+++ b/src/seavoice/pages/PricingPage.tsx
@@ -1,8 +1,12 @@
 
 import { motion } from 'framer-motion';
+import { MEETING_URL } from '../../constants/urls';
 import { Check, X } from 'lucide-react';
+import { MEETING_URL } from '../../constants/urls';
 import SupportPlan from '../../components/SupportPlan';
+import { MEETING_URL } from '../../constants/urls';
 import PriceCalculator from '../components/PriceCalculator';
+import { MEETING_URL } from '../../constants/urls';
 
 const PricingPage = () => {
   const plans = [
@@ -90,7 +94,7 @@ const PricingPage = () => {
       ],
       limitations: [],
       cta: 'Contact Us',
-      ctaUrl: 'https://meetings.hubspot.com/seasalt-ai/seasalt-meeting',
+      ctaUrl: '{MEETING_URL}',
       popular: false,
       cardStyle: 'bg-gradient-to-br from-green-400 to-green-600 text-white',
       buttonStyle: 'bg-green-600 hover:bg-green-700 text-white',
@@ -376,7 +380,7 @@ const PricingPage = () => {
                 </motion.button>
               </a>
               <a
-                href="https://meetings.hubspot.com/seasalt-ai/seasalt-meeting"
+                href={MEETING_URL}
                 target="_blank"
                 rel="noopener noreferrer"
               >

--- a/src/seavoice/pages/UnifiedHomePage.tsx
+++ b/src/seavoice/pages/UnifiedHomePage.tsx
@@ -1,11 +1,19 @@
 import { useState, useEffect } from 'react';
+import { MEETING_URL } from '../../constants/urls';
 import { motion, AnimatePresence } from 'framer-motion';
+import { MEETING_URL } from '../../constants/urls';
 import { Phone, BarChart3, CheckCircle, ArrowRight, Star, Bot, Users, Headphones, Building2, Zap, Clock, ChevronDown, Brain, Mic, Speaker } from 'lucide-react';
+import { MEETING_URL } from '../../constants/urls';
 import { useNavigate, useParams } from 'react-router-dom';
+import { MEETING_URL } from '../../constants/urls';
 import { useTranslation } from 'react-i18next';
+import { MEETING_URL } from '../../constants/urls';
 import VoiceDemo from '../components/VoiceDemo';
+import { MEETING_URL } from '../../constants/urls';
 import InteractiveCallDashboard from '../components/hero-variants/InteractiveCallDashboard';
+import { MEETING_URL } from '../../constants/urls';
 import VoiceConversationFlow from '../components/hero-variants/VoiceConversationFlow';
+import { MEETING_URL } from '../../constants/urls';
 
 const UnifiedHomePage = () => {
   const navigate = useNavigate();
@@ -487,7 +495,7 @@ const UnifiedHomePage = () => {
 
               <div className="flex flex-col sm:flex-row gap-6 justify-start mb-16">
                 <motion.a 
-                  href="https://meetings.hubspot.com/seasalt-ai/seasalt-meeting" 
+                  href={MEETING_URL} 
                   target="_blank" 
                   rel="noopener noreferrer" 
                   whileHover={{ scale: 1.05, y: -2 }}
@@ -932,7 +940,7 @@ const UnifiedHomePage = () => {
                 Join thousands of businesses that have transformed their customer service with AI that works 24/7, handles unlimited calls, and scales with your business.
               </p>
               <div className="flex flex-col sm:flex-row gap-4 justify-center">
-                <a href="https://meetings.hubspot.com/seasalt-ai/seasalt-meeting" target="_blank" rel="noopener noreferrer" className="bg-white text-purple-600 px-6 py-3 rounded-lg font-semibold hover:bg-purple-50 transition-colors">
+                <a href={MEETING_URL} target="_blank" rel="noopener noreferrer" className="bg-white text-purple-600 px-6 py-3 rounded-lg font-semibold hover:bg-purple-50 transition-colors">
                   Book a Demo
                 </a>
                 <a href="https://chat.seasalt.ai/signup" target="_blank" rel="noopener noreferrer" className="bg-purple-500 border-2 border-white text-white px-6 py-3 rounded-lg font-semibold hover:bg-purple-400 transition-colors">
@@ -1181,7 +1189,7 @@ const UnifiedHomePage = () => {
               </p>
               <div className="flex flex-col sm:flex-row gap-4 justify-center">
                 <a 
-                  href="https://meetings.hubspot.com/seasalt-ai/seasalt-meeting" 
+                  href={MEETING_URL} 
                   target="_blank" 
                   rel="noopener noreferrer" 
                   className="bg-white text-blue-600 px-6 py-3 rounded-lg font-semibold hover:bg-blue-50 transition-colors"
@@ -1218,7 +1226,7 @@ const UnifiedHomePage = () => {
             </p>
             <div className="flex flex-col sm:flex-row gap-4 justify-center">
               <a
-                href="https://meetings.hubspot.com/seasalt-ai/seasalt-meeting"
+                href={MEETING_URL}
                 target="_blank"
                 rel="noopener noreferrer"
               >

--- a/src/seavoice/pages/platform/LandlineMobilePage.tsx
+++ b/src/seavoice/pages/platform/LandlineMobilePage.tsx
@@ -1,6 +1,8 @@
 
 import { motion } from 'framer-motion';
+import { MEETING_URL } from '../../../constants/urls';
 import { Phone, Smartphone, Globe, Shield, Clock, CheckCircle } from 'lucide-react';
+import { MEETING_URL } from '../../../constants/urls';
 
 const LandlineMobilePage = () => {
   const features = [
@@ -267,7 +269,7 @@ const LandlineMobilePage = () => {
               Connect your landline and mobile infrastructure with AI voice agents in minutes
             </p>
             <a
-              href="https://meetings.hubspot.com/seasalt-ai/seasalt-meeting"
+              href={MEETING_URL}
               target="_blank"
               rel="noopener noreferrer"
             >

--- a/src/seavoice/pages/platform/VoipSipByocPage.tsx
+++ b/src/seavoice/pages/platform/VoipSipByocPage.tsx
@@ -1,6 +1,8 @@
 
 import { motion } from 'framer-motion';
+import { MEETING_URL } from '../../../constants/urls';
 import { Network, Server, Shield, Zap, Globe, Settings } from 'lucide-react';
+import { MEETING_URL } from '../../../constants/urls';
 
 const VoipSipByocPage = () => {
   const connectionTypes = [
@@ -81,7 +83,7 @@ const VoipSipByocPage = () => {
               direct SIP trunking, or bring your own carrier for complete control.
             </p>
             <a
-              href="https://meetings.hubspot.com/seasalt-ai/seasalt-meeting"
+              href={MEETING_URL}
               target="_blank"
               rel="noopener noreferrer"
             >
@@ -321,7 +323,7 @@ const VoipSipByocPage = () => {
             </p>
             <div className="flex flex-col sm:flex-row gap-4 justify-center">
               <a
-                href="https://meetings.hubspot.com/seasalt-ai/seasalt-meeting"
+                href={MEETING_URL}
                 target="_blank"
                 rel="noopener noreferrer"
               >

--- a/src/seavoice/pages/platform/WhatsAppVoicePage.tsx
+++ b/src/seavoice/pages/platform/WhatsAppVoicePage.tsx
@@ -1,6 +1,8 @@
 
 import { motion } from 'framer-motion';
+import { MEETING_URL } from '../../../constants/urls';
 import { MessageSquare, Globe, Users, Shield, CheckCircle, Smartphone } from 'lucide-react';
+import { MEETING_URL } from '../../../constants/urls';
 
 const WhatsAppVoicePage = () => {
   const features = [
@@ -398,7 +400,7 @@ const WhatsAppVoicePage = () => {
                 </motion.button>
               </a>
               <a
-                href="https://meetings.hubspot.com/seasalt-ai/seasalt-meeting"
+                href={MEETING_URL}
                 target="_blank"
                 rel="noopener noreferrer"
               >

--- a/src/seax/components/Footer.tsx
+++ b/src/seax/components/Footer.tsx
@@ -3,6 +3,7 @@ import { FaDiscord } from 'react-icons/fa';
 import { Link } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { useState } from 'react';
+import { MEETING_URL } from '../../constants/urls';
 import { motion, AnimatePresence } from 'framer-motion';
 
 // Custom WhatsApp icon component
@@ -506,7 +507,7 @@ const Footer = () => {
               Sign Up Now
             </a>
             <a
-              href="https://meetings.hubspot.com/seasalt-ai/seasalt-meeting/"
+              href={MEETING_URL}
               className="border-2 border-white text-white hover:bg-white hover:text-blue-600 px-6 sm:px-8 py-2.5 sm:py-3 rounded-lg font-semibold transition-all duration-200 text-sm sm:text-base"
             >
               Schedule Demo

--- a/src/seax/components/Hero.tsx
+++ b/src/seax/components/Hero.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next';
 import { motion } from 'framer-motion';
 import { Play, ArrowRight, MessageCircle, Phone, Mail } from 'lucide-react';
 import MassCommunicationFlow from './MassCommunicationFlow';
+import { MEETING_URL } from '../../constants/urls';
 
 const Hero = () => {
   const { i18n: _i18n } = useTranslation();
@@ -83,7 +84,7 @@ const Hero = () => {
             {/* CTA buttons */}
             <div className="flex flex-col sm:flex-row gap-4 justify-center lg:justify-start">
               <a
-                href="https://meetings.hubspot.com/seasalt-ai/seasalt-meeting/"
+                href={MEETING_URL}
                 className="bg-blue-600 text-white px-8 py-4 rounded-lg font-semibold hover:bg-blue-700 transition-colors flex items-center justify-center space-x-2 shadow-lg hover:shadow-xl"
               >
                 <span>Book a Demo</span>

--- a/src/seax/components/OmniChannelCalculator.tsx
+++ b/src/seax/components/OmniChannelCalculator.tsx
@@ -1,5 +1,7 @@
 import { useState } from 'react';
+import { MEETING_URL } from '../../constants/urls';
 import { Calculator, Users, Phone, MessageSquare, Info } from 'lucide-react';
+import { MEETING_URL } from '../../constants/urls';
 
 const OmniChannelCalculator = () => {
   const [billingPeriod, setBillingPeriod] = useState<'monthly' | 'yearly'>('monthly');
@@ -426,7 +428,7 @@ const OmniChannelCalculator = () => {
               Get Started with Omni-channel
             </a>
             <a
-              href="https://meetings.hubspot.com/seasalt-ai/seasalt-meeting/"
+              href={MEETING_URL}
               className="w-full border-2 border-blue-600 text-blue-600 hover:bg-blue-50 font-semibold py-3 px-6 rounded-lg transition-colors text-center inline-block"
             >
               Talk to Sales

--- a/src/seax/pages/Features.tsx
+++ b/src/seax/pages/Features.tsx
@@ -1,6 +1,9 @@
 import Header from '../components/Header';
+import { MEETING_URL } from '../../constants/urls';
 import SEOHelmet from '../../components/SEOHelmet';
+import { MEETING_URL } from '../../constants/urls';
 import { useTranslation } from 'react-i18next';
+import { MEETING_URL } from '../../constants/urls';
 import { 
   MessageSquare, 
   BarChart3, 
@@ -14,6 +17,7 @@ import {
   Building2
 } from 'lucide-react';
 import { seaxCoreFeatures } from '../data/seaxFeatures';
+import { MEETING_URL } from '../../constants/urls';
 
 const Features = () => {
   const { i18n: _i18n } = useTranslation();
@@ -345,7 +349,7 @@ const Features = () => {
           
           <div className="flex flex-col sm:flex-row gap-4 justify-center">
             <a
-              href="https://meetings.hubspot.com/seasalt-ai/seasalt-meeting/"
+              href={MEETING_URL}
               target="_blank"
               rel="noopener noreferrer"
               className="bg-blue-600 text-white px-8 py-4 rounded-lg font-semibold hover:bg-blue-700 transition-colors flex items-center justify-center space-x-2"

--- a/src/seax/pages/HowItWorks.tsx
+++ b/src/seax/pages/HowItWorks.tsx
@@ -1,9 +1,15 @@
 import React from 'react';
+import { MEETING_URL } from '../../constants/urls';
 import Header from '../components/Header';
+import { MEETING_URL } from '../../constants/urls';
 import Footer from '../components/Footer';
+import { MEETING_URL } from '../../constants/urls';
 import SEOHelmet from '../../components/SEOHelmet';
+import { MEETING_URL } from '../../constants/urls';
 import { useTranslation } from 'react-i18next';
+import { MEETING_URL } from '../../constants/urls';
 import { Upload, MessageSquare, BarChart3, ArrowRight, CheckCircle, Smartphone, Phone, Send } from 'lucide-react';
+import { MEETING_URL } from '../../constants/urls';
 
 const HowItWorks = () => {
   const { i18n: _i18n } = useTranslation();
@@ -321,7 +327,7 @@ const HowItWorks = () => {
             </a>
             
             <a
-              href="https://meetings.hubspot.com/seasalt-ai/seasalt-meeting/"
+              href={MEETING_URL}
               target="_blank"
               rel="noopener noreferrer"
               className="border-2 border-white text-white px-8 py-4 rounded-lg font-semibold hover:bg-white hover:text-blue-600 transition-colors"

--- a/src/seax/pages/Pricing.tsx
+++ b/src/seax/pages/Pricing.tsx
@@ -1,11 +1,19 @@
 import Header from '../components/Header';
+import { MEETING_URL } from '../../constants/urls';
 import Footer from '../components/Footer';
+import { MEETING_URL } from '../../constants/urls';
 import SEOHelmet from '../../components/SEOHelmet';
+import { MEETING_URL } from '../../constants/urls';
 import ROICalculator from '../components/ROICalculator';
+import { MEETING_URL } from '../../constants/urls';
 import SupportPlan from '../../components/SupportPlan';
+import { MEETING_URL } from '../../constants/urls';
 import OmniChannelCalculator from '../components/OmniChannelCalculator';
+import { MEETING_URL } from '../../constants/urls';
 import { useTranslation } from 'react-i18next';
+import { MEETING_URL } from '../../constants/urls';
 import { useState } from 'react';
+import { MEETING_URL } from '../../constants/urls';
 import { 
   Check, 
   ArrowRight, 
@@ -264,7 +272,7 @@ const Pricing = () => {
                 <div className="px-8 pb-8 mt-auto">
                   {tier.name === 'Custom' ? (
                     <a
-                      href="https://meetings.hubspot.com/seasalt-ai/seasalt-meeting/"
+                      href={MEETING_URL}
                       className="w-full py-3 px-6 rounded-lg font-semibold transition-all transform hover:scale-105 text-center inline-block bg-green-500 hover:bg-green-600 text-white"
                     >
                       {tier.cta}
@@ -470,7 +478,7 @@ const Pricing = () => {
             </a>
             
             <a
-              href="https://meetings.hubspot.com/seasalt-ai/seasalt-meeting/"
+              href={MEETING_URL}
               className="border-2 border-white text-white px-8 py-4 rounded-lg font-semibold hover:bg-white hover:text-blue-600 transition-colors"
             >
               Talk to Sales

--- a/src/seax/pages/Resources.tsx
+++ b/src/seax/pages/Resources.tsx
@@ -1,8 +1,13 @@
 import Header from '../components/Header';
+import { MEETING_URL } from '../../constants/urls';
 import SEOHelmet from '../../components/SEOHelmet';
+import { MEETING_URL } from '../../constants/urls';
 import { Link } from 'react-router-dom';
+import { MEETING_URL } from '../../constants/urls';
 import { useTranslation } from 'react-i18next';
+import { MEETING_URL } from '../../constants/urls';
 import { ArrowRight, Book, FileText, Video, MessageSquare, Download, ExternalLink, Users } from 'lucide-react';
+import { MEETING_URL } from '../../constants/urls';
 
 const Resources = () => {
   const { i18n } = useTranslation();
@@ -171,7 +176,7 @@ const Resources = () => {
           
           <div className="flex flex-col sm:flex-row gap-4 justify-center">
             <a
-              href="https://meetings.hubspot.com/seasalt-ai/seasalt-meeting/"
+              href={MEETING_URL}
               className="bg-indigo-600 text-white px-8 py-4 rounded-lg font-semibold hover:bg-indigo-700 transition-colors flex items-center justify-center space-x-2"
             >
               <span>Get Support</span>

--- a/src/seax/pages/SeaXHome.tsx
+++ b/src/seax/pages/SeaXHome.tsx
@@ -1,14 +1,25 @@
 import { useTranslation } from 'react-i18next';
+import { MEETING_URL } from '../../constants/urls';
 import { Link } from 'react-router-dom';
+import { MEETING_URL } from '../../constants/urls';
 import Header from '../components/Header';
+import { MEETING_URL } from '../../constants/urls';
 import Hero from '../components/Hero';
+import { MEETING_URL } from '../../constants/urls';
 import StatsCounter from '../components/StatsCounter';
+import { MEETING_URL } from '../../constants/urls';
 import Footer from '../components/Footer';
+import { MEETING_URL } from '../../constants/urls';
 import SEOHelmet from '../../components/SEOHelmet';
+import { MEETING_URL } from '../../constants/urls';
 import ScaleComparison from '../components/ScaleComparison';
+import { MEETING_URL } from '../../constants/urls';
 import RealTimeDashboard from '../components/RealTimeDashboard';
+import { MEETING_URL } from '../../constants/urls';
 import { SUPPORTED_LANGUAGES } from '../../constants/languages';
+import { MEETING_URL } from '../../constants/urls';
 import { MessageSquare, Phone, Zap, TrendingUp, Target, CheckCircle, Star, ArrowRight, BarChart3, Users, Upload, Smartphone, Send } from 'lucide-react';
+import { MEETING_URL } from '../../constants/urls';
 
 const SeaXHome = () => {
   const { i18n } = useTranslation();
@@ -445,7 +456,7 @@ const SeaXHome = () => {
           
           <div className="flex flex-col sm:flex-row gap-4 justify-center mb-12">
             <a
-              href="https://meetings.hubspot.com/seasalt-ai/seasalt-meeting"
+              href={MEETING_URL}
               className="bg-white text-blue-600 px-8 py-4 rounded-lg font-semibold hover:bg-gray-100 transition-colors inline-flex items-center justify-center space-x-2"
             >
               <span>Request a Personalized Demo</span>

--- a/src/seax/pages/channels/SMS.tsx
+++ b/src/seax/pages/channels/SMS.tsx
@@ -1,7 +1,11 @@
 import Header from '../../components/Header';
+import { MEETING_URL } from '../../../constants/urls';
 import Footer from '../../components/Footer';
+import { MEETING_URL } from '../../../constants/urls';
 import SEOHelmet from '../../../components/SEOHelmet';
+import { MEETING_URL } from '../../../constants/urls';
 import { useTranslation } from 'react-i18next';
+import { MEETING_URL } from '../../../constants/urls';
 import { 
   MessageSquare, 
   CheckCircle, 
@@ -134,7 +138,7 @@ const SMS = () => {
                   <ArrowRight className="w-5 h-5" />
                 </a>
                 <a
-                  href="https://meetings.hubspot.com/seasalt-ai/seasalt-meeting/"
+                  href={MEETING_URL}
                   target="_blank"
                   rel="noopener noreferrer"
                   className="border-2 border-green-600 text-green-600 px-8 py-4 rounded-lg font-semibold hover:bg-green-50 transition-colors text-center"
@@ -261,7 +265,7 @@ const SMS = () => {
             </a>
             
             <a
-              href="https://meetings.hubspot.com/seasalt-ai/seasalt-meeting/"
+              href={MEETING_URL}
               target="_blank"
               rel="noopener noreferrer"
               className="border-2 border-white text-white px-8 py-4 rounded-lg font-semibold hover:bg-white hover:text-green-600 transition-colors"

--- a/src/seax/pages/channels/WhatsApp.tsx
+++ b/src/seax/pages/channels/WhatsApp.tsx
@@ -1,7 +1,11 @@
 import Header from '../../components/Header';
+import { MEETING_URL } from '../../../constants/urls';
 import Footer from '../../components/Footer';
+import { MEETING_URL } from '../../../constants/urls';
 import SEOHelmet from '../../../components/SEOHelmet';
+import { MEETING_URL } from '../../../constants/urls';
 import { useTranslation } from 'react-i18next';
+import { MEETING_URL } from '../../../constants/urls';
 import { 
   MessageCircle, 
   CheckCircle, 
@@ -156,7 +160,7 @@ const WhatsApp = () => {
                   <ArrowRight className="w-5 h-5" />
                 </a>
                 <a
-                  href="https://meetings.hubspot.com/seasalt-ai/seasalt-meeting/"
+                  href={MEETING_URL}
                   target="_blank"
                   rel="noopener noreferrer"
                   className="border-2 border-green-600 text-green-600 px-8 py-4 rounded-lg font-semibold hover:bg-green-50 transition-colors text-center"
@@ -332,7 +336,7 @@ const WhatsApp = () => {
             </a>
             
             <a
-              href="https://meetings.hubspot.com/seasalt-ai/seasalt-meeting/"
+              href={MEETING_URL}
               target="_blank"
               rel="noopener noreferrer"
               className="border-2 border-white text-white px-8 py-4 rounded-lg font-semibold hover:bg-white hover:text-green-600 transition-colors"

--- a/src/seax/pages/solutions/AppointmentReminders.tsx
+++ b/src/seax/pages/solutions/AppointmentReminders.tsx
@@ -1,9 +1,15 @@
 import Header from '../../components/Header';
+import { MEETING_URL } from '../../../constants/urls';
 import Footer from '../../components/Footer';
+import { MEETING_URL } from '../../../constants/urls';
 import SEOHelmet from '../../../components/SEOHelmet';
+import { MEETING_URL } from '../../../constants/urls';
 import { Link } from 'react-router-dom';
+import { MEETING_URL } from '../../../constants/urls';
 import { useTranslation } from 'react-i18next';
+import { MEETING_URL } from '../../../constants/urls';
 import { ArrowRight, Calendar, Clock, MessageSquare, Users, Bell, BarChart3 } from 'lucide-react';
+import { MEETING_URL } from '../../../constants/urls';
 
 const AppointmentReminders = () => {
   const { i18n } = useTranslation();
@@ -90,7 +96,7 @@ const AppointmentReminders = () => {
           
           <div className="flex flex-col sm:flex-row gap-4 justify-center">
             <a
-              href="https://meetings.hubspot.com/seasalt-ai/seasalt-meeting/"
+              href={MEETING_URL}
               target="_blank"
               rel="noopener noreferrer"
               className="bg-blue-600 text-white px-8 py-4 rounded-lg font-semibold hover:bg-blue-700 transition-colors flex items-center justify-center space-x-2"
@@ -218,7 +224,7 @@ const AppointmentReminders = () => {
           </p>
           
           <a
-            href="https://meetings.hubspot.com/seasalt-ai/seasalt-meeting/"
+            href={MEETING_URL}
             target="_blank"
             rel="noopener noreferrer"
             className="bg-white text-blue-600 px-8 py-4 rounded-lg font-semibold hover:bg-gray-50 transition-colors inline-flex items-center space-x-2"

--- a/src/seax/pages/solutions/CustomerEngagement.tsx
+++ b/src/seax/pages/solutions/CustomerEngagement.tsx
@@ -1,9 +1,15 @@
 import Header from '../../components/Header';
+import { MEETING_URL } from '../../../constants/urls';
 import Footer from '../../components/Footer';
+import { MEETING_URL } from '../../../constants/urls';
 import SEOHelmet from '../../../components/SEOHelmet';
+import { MEETING_URL } from '../../../constants/urls';
 import { Link } from 'react-router-dom';
+import { MEETING_URL } from '../../../constants/urls';
 import { useTranslation } from 'react-i18next';
+import { MEETING_URL } from '../../../constants/urls';
 import { ArrowRight, Users, MessageSquare, Heart, BarChart3, Target, Zap } from 'lucide-react';
+import { MEETING_URL } from '../../../constants/urls';
 
 const CustomerEngagement = () => {
   const { i18n } = useTranslation();
@@ -89,7 +95,7 @@ const CustomerEngagement = () => {
           
           <div className="flex flex-col sm:flex-row gap-4 justify-center">
             <a
-              href="https://meetings.hubspot.com/seasalt-ai/seasalt-meeting/"
+              href={MEETING_URL}
               target="_blank"
               rel="noopener noreferrer"
               className="bg-blue-600 text-white px-8 py-4 rounded-lg font-semibold hover:bg-blue-700 transition-colors flex items-center justify-center space-x-2"
@@ -217,7 +223,7 @@ const CustomerEngagement = () => {
           </p>
           
           <a
-            href="https://meetings.hubspot.com/seasalt-ai/seasalt-meeting/"
+            href={MEETING_URL}
             target="_blank"
             rel="noopener noreferrer"
             className="bg-white text-blue-600 px-8 py-4 rounded-lg font-semibold hover:bg-gray-50 transition-colors inline-flex items-center space-x-2"

--- a/src/seax/pages/solutions/EmergencyAlerts.tsx
+++ b/src/seax/pages/solutions/EmergencyAlerts.tsx
@@ -1,9 +1,15 @@
 import Header from '../../components/Header';
+import { MEETING_URL } from '../../../constants/urls';
 import Footer from '../../components/Footer';
+import { MEETING_URL } from '../../../constants/urls';
 import SEOHelmet from '../../../components/SEOHelmet';
+import { MEETING_URL } from '../../../constants/urls';
 import { Link } from 'react-router-dom';
+import { MEETING_URL } from '../../../constants/urls';
 import { useTranslation } from 'react-i18next';
+import { MEETING_URL } from '../../../constants/urls';
 import { ArrowRight, AlertTriangle, Clock, Users, Shield, Bell, MessageSquare } from 'lucide-react';
+import { MEETING_URL } from '../../../constants/urls';
 
 const EmergencyAlerts = () => {
   const { i18n } = useTranslation();
@@ -90,7 +96,7 @@ const EmergencyAlerts = () => {
 
           <div className="flex flex-col sm:flex-row gap-4 justify-center">
             <a
-              href="https://meetings.hubspot.com/seasalt-ai/seasalt-meeting/"
+              href={MEETING_URL}
               target="_blank"
               rel="noopener noreferrer"
               className="bg-red-600 text-white px-8 py-4 rounded-lg font-semibold hover:bg-red-700 transition-colors flex items-center justify-center space-x-2"
@@ -218,7 +224,7 @@ const EmergencyAlerts = () => {
           </p>
 
           <a
-            href="https://meetings.hubspot.com/seasalt-ai/seasalt-meeting/"
+            href={MEETING_URL}
             target="_blank"
             rel="noopener noreferrer"
             className="bg-white text-red-600 px-8 py-4 rounded-lg font-semibold hover:bg-gray-50 transition-colors inline-flex items-center space-x-2"

--- a/src/seax/pages/solutions/SolutionsOverview.tsx
+++ b/src/seax/pages/solutions/SolutionsOverview.tsx
@@ -1,7 +1,11 @@
 import Header from '../../components/Header';
+import { MEETING_URL } from '../../../constants/urls';
 import Footer from '../../components/Footer';
+import { MEETING_URL } from '../../../constants/urls';
 import SEOHelmet from '../../../components/SEOHelmet';
+import { MEETING_URL } from '../../../constants/urls';
 import { ArrowRight, CheckCircle } from 'lucide-react';
+import { MEETING_URL } from '../../../constants/urls';
 
 const SolutionsOverview = () => {
 
@@ -28,7 +32,7 @@ const SolutionsOverview = () => {
           
           <div className="flex flex-col sm:flex-row gap-4 justify-center">
             <a
-              href="https://meetings.hubspot.com/seasalt-ai/seasalt-meeting/"
+              href={MEETING_URL}
               target="_blank"
               rel="noopener noreferrer"
               className="bg-blue-600 text-white px-8 py-4 rounded-lg font-semibold hover:bg-blue-700 transition-colors flex items-center justify-center space-x-2"
@@ -111,7 +115,7 @@ const SolutionsOverview = () => {
           </p>
           
           <a
-            href="https://meetings.hubspot.com/seasalt-ai/seasalt-meeting/"
+            href={MEETING_URL}
             target="_blank"
             rel="noopener noreferrer"
             className="bg-white text-blue-600 px-8 py-4 rounded-lg font-semibold hover:bg-gray-50 transition-colors inline-flex items-center space-x-2"


### PR DESCRIPTION
- Created MEETING_URL constant in src/constants/urls.ts
- Replaced all hardcoded https://meetings.hubspot.com/seasalt-ai/seasalt-meeting URLs
- Added proper imports across all affected files (336 total usages)
- Improved maintainability by centralizing URL management