### PR TITLE
fix(i18n): return key for missing translations

### DIFF
--- a/src/i18n/helpers.ts
+++ b/src/i18n/helpers.ts
@@ -158,30 +158,7 @@ function createTranslationFunction(translations: any, lang?: SupportedLanguage, 
       }
     }
     
-    // return key; // 找不到翻譯時返回 key
-    
-    // 如果參數中包含 returnObjects: true，直接返回結果
-    if (params?.returnObjects === true) {
-      return result;
-    }
-    
-    if (typeof result === 'string') {
-      // 簡單的參數替換
-      if (params) {
-        return result.replace(/\{\{(\w+)\}\}/g, (match, paramName) => {
-          return params[paramName]?.toString() || match;
-        });
-      }
-      return result;
-    }
-    
-    // 對於其他類型（數組、對象）也返回結果
-    if (Array.isArray(result) || (typeof result === 'object' && result !== null)) {
-      return result;
-    }
-    
-    // return key;
-    return null;
+    return key; // 找不到翻譯時返回 key
   };
 }
 


### PR DESCRIPTION
This PR fixes a bug where the ld+json for breadcrumbs would have a null value for the name property if a translation was missing. This was causing errors in Google Search Console.\n\nThe t function in src/i18n/helpers.ts was returning null when a translation key was not found. This PR changes that behavior to return the key itself.\n\nThis change has two benefits:\n1. It fixes the ld+json error.\n2. It makes it easier to spot missing translations on the website, as the raw key will be displayed.\n\nI also removed a redundant and non-functional block of code from the createTranslationFunction to improve code clarity.